### PR TITLE
Support `trackMutableRef: pr-123`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ If the value at `ref` is already a git commit SHA, and the subtree named by
 This means that changes to other parts of the repository will not result in
 "no-op" changes to this line.
 
+As a convenience, if `trackMutableRef` has the form `pr-123` followed by digits,
+it is converted to `pull/123/head`, which is the ref syntax GitHub uses for PRs.
+
 The effect of using `trackMutableRef` is similar to just specifying the mutable
 ref directly as the ref which the ArgoCD application tracks. But by explicitly
 changing the config file for each update, you can clearly see the difference

--- a/src/github.ts
+++ b/src/github.ts
@@ -37,11 +37,12 @@ export class OctokitGitHubClient {
     ref,
   }: ResolveRefToShaOptions): Promise<string> {
     const { owner, repo } = parseRepoURL(repoURL);
+    const prNumber = ref.match(/^pr-([0-9]+)$/)?.[1];
     const sha = (
       await this.octokit.rest.repos.getCommit({
         owner,
         repo,
-        ref,
+        ref: prNumber ? `pull/${prNumber}/head` : ref,
         mediaType: {
           format: 'sha',
         },


### PR DESCRIPTION
This matches the syntax we are using by default for Docker image PR labels, so you can set `trackMutableRef` and `trackMutableTag` to the same values to switch to a pull request.

(However, this value will not work for `ref` itself.)