### PR TITLE
Cache all GitHub and Artifact Registry API calls

### DIFF
--- a/__tests__/caching.test.ts
+++ b/__tests__/caching.test.ts
@@ -1,0 +1,84 @@
+import { CachingDockerRegistryClient } from '../src/artifactRegistry';
+import { CachingGitHubClient } from '../src/github';
+
+describe('CachingDockerRegistryClient caches', () => {
+  it('getAllEquivalentTags caches', async () => {
+    let call = 0;
+    const client = new CachingDockerRegistryClient({
+      async getAllEquivalentTags() {
+        return [(++call).toString()];
+      },
+    });
+
+    async function exp(
+      dockerImageRepository: string,
+      tag: string,
+      ret: string,
+    ): Promise<void> {
+      expect(
+        await client.getAllEquivalentTags({ dockerImageRepository, tag }),
+      ).toStrictEqual([ret]);
+    }
+
+    await exp('x', 'y', '1');
+    await exp('x', 'y', '1');
+    await exp('x', 'z', '2');
+    await exp('w', 'y', '3');
+    await exp('x', 'y', '1');
+  });
+});
+
+describe('CachingGitHubClient caches', () => {
+  it('resolveRefToSha caches', async () => {
+    let call = 0;
+    const client = new CachingGitHubClient({
+      async resolveRefToSha() {
+        return (++call).toString();
+      },
+      async getTreeSHAForPath() {
+        return '';
+      },
+    });
+
+    async function exp(
+      repoURL: string,
+      ref: string,
+      ret: string,
+    ): Promise<void> {
+      expect(await client.resolveRefToSha({ repoURL, ref })).toBe(ret);
+    }
+
+    await exp('x', 'y', '1');
+    await exp('x', 'y', '1');
+    await exp('x', 'z', '2');
+    await exp('w', 'y', '3');
+    await exp('x', 'y', '1');
+  });
+  it('getTreeSHAForPath caches', async () => {
+    let call = 0;
+    const client = new CachingGitHubClient({
+      async resolveRefToSha() {
+        return '';
+      },
+      async getTreeSHAForPath() {
+        return (++call).toString();
+      },
+    });
+
+    async function exp(
+      repoURL: string,
+      ref: string,
+      path: string,
+      ret: string,
+    ): Promise<void> {
+      expect(await client.getTreeSHAForPath({ repoURL, ref, path })).toBe(ret);
+    }
+
+    await exp('x', 'y', 'p', '1');
+    await exp('x', 'y', 'p', '1');
+    await exp('x', 'z', 'p', '2');
+    await exp('w', 'y', 'p', '3');
+    await exp('x', 'y', 'p', '1');
+    await exp('x', 'y', 'pp', '4');
+  });
+});

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -3047,6 +3047,25 @@ Apache-2.0
    limitations under the License.
 
 
+lru-cache
+ISC
+The ISC License
+
+Copyright (c) 2010-2023 Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
 minimatch
 ISC
 The ISC License

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@google-cloud/artifact-registry": "^3.1.0",
         "@octokit/plugin-throttling": "^8.1.3",
         "lodash": "^4.17.21",
+        "lru-cache": "^10.2.0",
         "re2-wasm": "^1.0.2",
         "yaml": "^2.3.4"
       },
@@ -268,6 +269,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -6025,12 +6035,11 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@google-cloud/artifact-registry": "^3.1.0",
     "@octokit/plugin-throttling": "^8.1.3",
     "lodash": "^4.17.21",
+    "lru-cache": "^10.2.0",
     "re2-wasm": "^1.0.2",
     "yaml": "^2.3.4"
   },


### PR DESCRIPTION
In our typical monorepo-based usage, we're asking
"what sha is main in the monorepo" many many
times. And if multiple installations are at the
same version (eg dev and staging) or use the same
image, we're asking the same questions there too.

Use non-configurable lru-cache with 1024 entries
each for now.