### PR TITLE
New 'parallelism' input to run files in parallel

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   
   promotion-target-regexp:
     description: 'Only process promote instructions for targets matching this regexp'
+  
+  parallelism:
+    description: 'How many files to process in parallel'
+    default: '1'
 
 outputs:
   sanitized-promotion-target-regexp:

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -1232,6 +1232,29 @@ SOFTWARE.
 agent-base
 MIT
 
+async
+MIT
+Copyright (c) 2010-2018 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 balanced-match
 MIT
 (MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "@actions/glob": "^0.4.0",
         "@google-cloud/artifact-registry": "^3.1.0",
         "@octokit/plugin-throttling": "^8.1.3",
+        "async": "^3.2.5",
         "lodash": "^4.17.21",
         "lru-cache": "^10.2.0",
         "re2-wasm": "^1.0.2",
         "yaml": "^2.3.4"
       },
       "devDependencies": {
+        "@types/async": "^3.2.24",
         "@types/jest": "29.5.12",
         "@types/lodash": "4.14.202",
         "@types/node": "20.11.19",
@@ -1669,6 +1671,12 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/async": {
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.24.tgz",
+      "integrity": "sha512-8iHVLHsCCOBKjCF2KwFe0p9Z3rfM9mL+sSP8btyR5vTjJRAqpBYD28/ZLgXPf0pjG1VxOvtCV/BgXkQbpSe8Hw==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -2353,6 +2361,11 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,14 @@
     "@actions/glob": "^0.4.0",
     "@google-cloud/artifact-registry": "^3.1.0",
     "@octokit/plugin-throttling": "^8.1.3",
+    "async": "^3.2.5",
     "lodash": "^4.17.21",
     "lru-cache": "^10.2.0",
     "re2-wasm": "^1.0.2",
     "yaml": "^2.3.4"
   },
   "devDependencies": {
+    "@types/async": "^3.2.24",
     "@types/jest": "29.5.12",
     "@types/lodash": "4.14.202",
     "@types/node": "20.11.19",


### PR DESCRIPTION
For now, setting this to a non-1 number will have a terrible effect on logging (they all just interweave, and the `group` calls don't match up).

On our repo it takes dry run from 54 to 20 seconds. Seems worth merging as long as we follow up soon to fix the logging.