### PR TITLE
New output: suggested-promotion-branch-name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,10 @@ inputs:
 
 outputs:
   sanitized-promotion-target-regexp:
-    description: 'The promotion-target-regexp input with special characters changed to underscores; appropriate for constructing a branch name'
+    description: 'DEPRECATED: The promotion-target-regexp input with special characters changed to underscores; appropriate for constructing a branch name'
+
+  suggested-promotion-branch-name:
+    description: 'A combination of the promotion-target-regexp and files inputs with special characters changed to underscores; appropriate for constructing a branch name'
 
 runs:
   using: node20

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,9 +60,17 @@ async function processFile(filename: string): Promise<void> {
         contents,
         promotionTargetRegexp || null,
       );
+      // Legacy: remove this once users switch over to suggested-promotion-branch-name.
       core.setOutput(
         'sanitized-promotion-target-regexp',
-        promotionTargetRegexp.replaceAll(/[^-a-zA-Z0-0._]/g, '_'),
+        promotionTargetRegexp.replaceAll(/[^-a-zA-Z0-9._]/g, '_'),
+      );
+      core.setOutput(
+        'suggested-promotion-branch-name',
+        `${promotionTargetRegexp}_${core.getInput('files')}`.replaceAll(
+          /[^-a-zA-Z0-9._]/g,
+          '_',
+        ),
       );
     }
 


### PR DESCRIPTION
Previously we combined sanitized-promotion-target-regexp with the subdirectory when creating a branch, but that breaks if you want to have two nested directories that each have a branch, because GH branches cannot be "nested" inside each other with slashes.

Deprecate sanitized-promotion-target-regexp.

Also fix typo in regexp (0-9 vs 0-0).