### PR TITLE
Allow `track` instead of needing both `trackMutable{Ref,Tag}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ contains the keys `repoURL`, `path`, `trackMutableRef` and `ref`, then this
 action can update the value at `ref` to be equal to the current git SHA for the
 ref named by `trackMutableRef` in the repository named by `repoURL`. (The
 `repoURL` and `path` keys may also be found in a `gitConfig` block under the
-top-level `global` block.)
+top-level `global` block. You may also specify the mutable ref to track under
+the key `track` at the same level as `gitConfig`; in this case, the same value
+will be used for Docker tag tracking.)
 
 If the value at `ref` is already a git commit SHA, and the subtree named by
 `path` is identical at the commit it names and the commit named by
@@ -115,7 +117,9 @@ block contains the keys `repository`, `trackMutableTag` and `tag`, then this
 action can update the value at `tag` to be equal to an "immutable" tag which
 points at the same image version as the tag named in `trackMutableTag` for the
 image named by `repository`. (The `repository` key may also be found in a
-`dockerImage` block under the top-level `global` block.)
+`dockerImage` block under the top-level `global` block. You may also specify the
+mutable tag to track under the key `track` at the same level as `dockerImage`;
+in this case, the same value will be used for git ref tracking.)
 
 Specifically, this automation treats as immutable any tag starting with the
 value of `trackMutableTag` followed by `---`. The assumption is that a build

--- a/__tests__/__fixtures__/update-docker-tags/sample.yaml
+++ b/__tests__/__fixtures__/update-docker-tags/sample.yaml
@@ -28,3 +28,9 @@ some-service-dev4:
     repository: foo
     trackMutableTag: should-roll-back-not-forward
     tag: should-roll-back-not-forward---000150-abcd
+
+some-service-top-level:
+  track: from-mutable
+  dockerImage:
+    repository: foo
+    tag: from-mutable

--- a/__tests__/__fixtures__/update-git-refs/sample.yaml
+++ b/__tests__/__fixtures__/update-git-refs/sample.yaml
@@ -32,3 +32,10 @@ another:
     path: services/hello-world
     ref: abcdef   # this becomes a number and will definitely need to be quoted
     trackMutableRef: make-it-numeric
+
+some-service-top-level:
+  track: pr-1234
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: "abcdef"   # this should change but stay double-quoted!

--- a/__tests__/__snapshots__/update-docker-tags.test.ts.snap
+++ b/__tests__/__snapshots__/update-docker-tags.test.ts.snap
@@ -31,5 +31,11 @@ some-service-dev4:
     repository: foo
     trackMutableTag: should-roll-back-not-forward
     tag: should-roll-back-not-forward---000100-abcd
+
+some-service-top-level:
+  track: from-mutable
+  dockerImage:
+    repository: foo
+    tag: from-mutable---000123-abcd
 "
 `;

--- a/__tests__/__snapshots__/update-git-refs.test.ts.snap
+++ b/__tests__/__snapshots__/update-git-refs.test.ts.snap
@@ -68,5 +68,12 @@ another:
     path: services/hello-world
     ref: '12345678'   # this becomes a number and will definitely need to be quoted
     trackMutableRef: make-it-numeric
+
+some-service-top-level:
+  track: pr-1234
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: "immutable-pr-1234-hooray"   # this should change but stay double-quoted!
 "
 `;

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
     description: 'GitHub token to read refs and trees; only needed if update-git-refs is set'
   
   update-git-refs:
-    description: 'Process trackMutableRef instructions'
+    description: 'Update tracked gitConfig.ref fields'
     default: 'false'
   
   update-docker-tags-for-artifact-registry-repository:
-    description: 'Process trackMutableTag instructions; must be set to a string of the form `projects/PROJECT/locations/LOCATION/repositories/REPOSITORY`'
+    description: 'Updated tracked dockerImage.tag fields; must be set to a string of the form `projects/PROJECT/locations/LOCATION/repositories/REPOSITORY`'
   
   update-promoted-values:
     description: 'Process promote instructions'

--- a/src/update-docker-tags.ts
+++ b/src/update-docker-tags.ts
@@ -74,7 +74,11 @@ function findTrackables(doc: yaml.Document.Parsed): Trackable[] {
     const dockerImageRepository =
       getStringValue(dockerImageBlock, 'repository') ??
       globalDockerImageRepository;
-    const trackMutableTag = getStringValue(dockerImageBlock, 'trackMutableTag');
+    // Tracking can be specified at `dockerImage.trackMutableTag` or just at
+    // `track`.
+    const trackMutableTag =
+      getStringValue(dockerImageBlock, 'trackMutableTag') ??
+      getStringValue(value, 'track');
     const tagScalarTokenAndValue = getStringAndScalarTokenFromMap(
       dockerImageBlock,
       'tag',

--- a/src/update-git-refs.ts
+++ b/src/update-git-refs.ts
@@ -69,7 +69,11 @@ function findTrackables(doc: yaml.Document.Parsed): Trackable[] {
 
     const repoURL = getStringValue(gitConfigBlock, 'repoURL') ?? globalRepoURL;
     const path = getStringValue(gitConfigBlock, 'path') ?? globalPath;
-    const trackMutableRef = getStringValue(gitConfigBlock, 'trackMutableRef');
+    // Tracking can be specified at `gitConfig.trackMutableRef` or just at
+    // `track`.
+    const trackMutableRef =
+      getStringValue(gitConfigBlock, 'trackMutableRef') ??
+      getStringValue(value, 'track');
     const refScalarTokenAndValue = getStringAndScalarTokenFromMap(
       gitConfigBlock,
       'ref',


### PR DESCRIPTION
This lets us replace

```
dev:
  gitConfig:
    trackMutableRef: main
    ref: f7bc3479736a5d6e122fee358cc71d70fdf3a56b
  dockerImage:
    trackMutableTag: main
    tag: main---0013278-2024.02-gc333ebaf5a
```

with

```
dev:
  track: main
  gitConfig:
    ref: f7bc3479736a5d6e122fee358cc71d70fdf3a56b
  dockerImage:
    tag: main---0013278-2024.02-gc333ebaf5a
```

which is good enough for most cases!

The old values take precedence over the new one if both are provided.