### PR TITLE
Take docker tag sha if present and tree sha matches

### DIFF
--- a/__tests__/__fixtures__/update-git-refs/docker-tree-sha.yaml
+++ b/__tests__/__fixtures__/update-git-refs/docker-tree-sha.yaml
@@ -1,0 +1,27 @@
+updated:
+  track: main
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: old
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3241
+
+
+not-updated:
+  gitConfig:
+    trackMutableRef: main
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: old
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3241
+
+diff-tree-sha:
+  track: main
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: old
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3240

--- a/__tests__/__fixtures__/update-git-refs/docker-tree-sha.yaml
+++ b/__tests__/__fixtures__/update-git-refs/docker-tree-sha.yaml
@@ -8,14 +8,14 @@ updated:
     tag: main---0013323-2024.03-gd97b3a3241
 
 
-not-updated:
+no-sha-found:
   gitConfig:
     trackMutableRef: main
     repoURL: https://github.com/apollographql/some-repo.git
     path: services/hello-world
     ref: old
   dockerImage:
-    tag: main---0013323-2024.03-gd97b3a3241
+    tag: main---0013323-2024.03-d97b3a3
 
 diff-tree-sha:
   track: main

--- a/__tests__/__snapshots__/update-git-refs.test.ts.snap
+++ b/__tests__/__snapshots__/update-git-refs.test.ts.snap
@@ -11,14 +11,14 @@ exports[`action handle docker tag 1`] = `
     tag: main---0013323-2024.03-gd97b3a3241
 
 
-not-updated:
+no-sha-found:
   gitConfig:
     trackMutableRef: main
     repoURL: https://github.com/apollographql/some-repo.git
     path: services/hello-world
     ref: old
   dockerImage:
-    tag: main---0013323-2024.03-gd97b3a3241
+    tag: main---0013323-2024.03-d97b3a3
 
 diff-tree-sha:
   track: main

--- a/__tests__/__snapshots__/update-git-refs.test.ts.snap
+++ b/__tests__/__snapshots__/update-git-refs.test.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`action handle docker tag 1`] = `
+"updated:
+  track: main
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: d97b3a3241
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3241
+
+
+not-updated:
+  gitConfig:
+    trackMutableRef: main
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: old
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3241
+
+diff-tree-sha:
+  track: main
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: old
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3240"
+`;
+
 exports[`action only changes ref when tree sha changes 1`] = `
 "some-service-tree:
   gitConfig:

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -67,7 +67,7 @@ describe('action', () => {
   it('handle docker tag', async () => {
     const mockGithubClientTreeSHA: GitHubClient = {
       async resolveRefToSHA({ ref }) {
-        return ref === 'main' ? 'new' : 'old';
+        return ref === 'main' ? 'new' : ref;
       },
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'd97b3a3240' ? 'bad' : 'aaaa';

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -63,4 +63,21 @@ describe('action', () => {
       await updateGitRefs(contents, mockGithubClientTreeSHA),
     ).toMatchSnapshot();
   });
+
+  it('handle docker tag', async () => {
+    const mockGithubClientTreeSHA: GitHubClient = {
+      async resolveRefToSHA({ ref }) {
+        return ref === 'main' ? 'new' : 'old';
+      },
+      async getTreeSHAForPath({ commitSHA }) {
+        return commitSHA === 'd97b3a3240' ? 'bad' : 'aaaa';
+      },
+    };
+
+    const contents = await fixture('docker-tree-sha.yaml');
+
+    expect(
+      await updateGitRefs(contents, mockGithubClientTreeSHA),
+    ).toMatchSnapshot();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,12 +63,12 @@ async function processFile(
   return core.group(`Processing ${filename}`, async () => {
     let contents = await readFile(filename, 'utf-8');
 
-    if (gitHubClient) {
-      contents = await updateGitRefs(contents, gitHubClient);
-    }
-
     if (dockerRegistryClient) {
       contents = await updateDockerTags(contents, dockerRegistryClient);
+    }
+
+    if (gitHubClient) {
+      contents = await updateGitRefs(contents, gitHubClient);
     }
 
     if (core.getBooleanInput('update-promoted-values')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ async function processFile(
       contents = await updateDockerTags(contents, dockerRegistryClient);
     }
 
+    // The git refs depend on the docker tag potentially so we want to update it after the
+    // docker tags are updated.
     if (gitHubClient) {
       contents = await updateGitRefs(contents, gitHubClient);
     }

--- a/src/update-git-refs.ts
+++ b/src/update-git-refs.ts
@@ -203,7 +203,10 @@ async function checkRefsAgainstGitHubAndModifyScalars(
     // It's OK if the current one is null because that's what we're overwriting, but we shouldn't
     // overwrite *to* something that doesn't exist.
     core.info(
-      `for path ${trackable.path}, got tree shas ${currentTreeSHA} for ${trackable.ref} and ${trackedTreeSHA} for ${trackedRefCommitSHA}`,
+      `for path ${trackable.path}, got tree shas` +
+        ` current: ${currentTreeSHA} for ${trackable.ref}` +
+        ` tracked: ${trackedTreeSHA} for ${trackedRefCommitSHA}` +
+        ` docker: ${dockerTreeSha} for ${dockerRefCommitSHA}`,
     );
 
     // The second check shouldn't be neccesary since dockerTreeSha is only

--- a/src/update-git-refs.ts
+++ b/src/update-git-refs.ts
@@ -88,10 +88,9 @@ function findTrackables(doc: yaml.Document.Parsed): Trackable[] {
         throw Error(`Document has \`${key}.dockerImage\` that is not a map`);
       }
 
-      const tagScalarTokenAndValue = getStringValue(dockerImageBlock, 'tag');
+      const tag = getStringValue(dockerImageBlock, 'tag');
 
-      const gitCommitMatches =
-        tagScalarTokenAndValue?.match(/-g([0-9a-fA-F]+)$/);
+      const gitCommitMatches = tag?.match(/-g([0-9a-fA-F]+)$/);
       if (gitCommitMatches) {
         maybeDockerCommit = gitCommitMatches[1];
       }
@@ -158,7 +157,7 @@ async function checkRefsAgainstGitHubAndModifyScalars(
         })
       : null;
 
-    const dockerTreeSha = dockerRefCommitSHA
+    const dockerTreeSHA = dockerRefCommitSHA
       ? await gitHubClient.getTreeSHAForPath({
           repoURL: trackable.repoURL,
           commitSHA: dockerRefCommitSHA,
@@ -177,18 +176,18 @@ async function checkRefsAgainstGitHubAndModifyScalars(
       `for path ${trackable.path}, got tree shas` +
         ` current: ${currentTreeSHA} for ${trackable.ref}` +
         ` tracked: ${trackedTreeSHA} for ${trackedRefCommitSHA}` +
-        ` docker: ${dockerTreeSha} for ${dockerRefCommitSHA}`,
+        ` docker: ${dockerTreeSHA} for ${dockerRefCommitSHA}`,
     );
 
-    // The second check shouldn't be neccesary since dockerTreeSha is only
+    // The second check shouldn't be neccesary since dockerTreeSHA is only
     // defined if dockerRefCommitSha is defined, but TypeScript doesn't know
-    if (dockerTreeSha === trackedTreeSHA && dockerRefCommitSHA) {
+    if (dockerTreeSHA === trackedTreeSHA && dockerRefCommitSHA) {
       if (dockerRefCommitSHA !== trackable.ref) {
         core.info('(using docker sha)');
         trackable.refScalarTokenWriter.write(dockerRefCommitSHA);
       } else {
         // Commit sha is already whats written so no changes
-        core.info('(unchanged)');
+        core.info('(matches docker, unchanged)');
       }
     } else if (currentTreeSHA === trackedTreeSHA) {
       if (currentRefCommitSHA !== trackable.ref) {
@@ -200,7 +199,7 @@ async function checkRefsAgainstGitHubAndModifyScalars(
         core.info('(unchanged)');
       }
     } else {
-      core.info('(updated to latest form ref!)');
+      core.info('(updated to latest from ref!)');
       trackable.refScalarTokenWriter.write(trackedRefCommitSHA);
     }
   }


### PR DESCRIPTION
We would like the revision in argo-cd to generally align with the "latest" thing deployed. Currently if we update the docker image we don't update the revision so the revision in the UI will the last time the helm chart was updated.

Instead we are now going to take docker commit tag if:
- We can extract a git commit ends in `-g{commit}`
- The commit has the same tree sha as the tracked tree sha
- `track` is used instead of `trackMutableRef` implying shared tracking between docker and helm chart. 

Theoretically to be fully accurate we would want to compare which git sha between the docker tag and the current tag is later so we don't "bounce backwards", but that should rarely happen. Most of the time we are updating the code only, and this should handle that case nicely.