### PR TITLE
update-git-refs: don't error if current or Docker ref unknown

### DIFF
--- a/__tests__/__snapshots__/update-git-refs.test.ts.snap
+++ b/__tests__/__snapshots__/update-git-refs.test.ts.snap
@@ -30,6 +30,46 @@ diff-tree-sha:
     tag: main---0013323-2024.03-gd97b3a3240"
 `;
 
+exports[`action handle docker tag with unknown commit 1`] = `
+"updated:
+  track: main
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: d97b3a3241
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3241
+
+
+no-sha-found:
+  gitConfig:
+    trackMutableRef: main
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: new
+  dockerImage:
+    tag: main---0013323-2024.03-d97b3a3
+
+diff-tree-sha:
+  track: main
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: new
+  dockerImage:
+    tag: main---0013323-2024.03-gd97b3a3240"
+`;
+
+exports[`action handles unknown current ref 1`] = `
+"some-service-tree:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    trackMutableRef: main
+    ref: new
+"
+`;
+
 exports[`action only changes ref when tree sha changes 1`] = `
 "some-service-tree:
   gitConfig:

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -64,6 +64,26 @@ describe('action', () => {
     ).toMatchSnapshot();
   });
 
+  it('handles unknown current ref', async () => {
+    const mockGithubClientTreeSHA: GitHubClient = {
+      async resolveRefToSHA({ ref }) {
+        if (ref === 'old') {
+          throw Error('unknown ref');
+        }
+        return 'new';
+      },
+      async getTreeSHAForPath() {
+        return 'aaaa';
+      },
+    };
+
+    const contents = await fixture('tree-sha.yaml');
+
+    expect(
+      await updateGitRefs(contents, mockGithubClientTreeSHA),
+    ).toMatchSnapshot();
+  });
+
   it('handle docker tag', async () => {
     const mockGithubClientTreeSHA: GitHubClient = {
       async resolveRefToSHA({ ref }) {
@@ -71,6 +91,26 @@ describe('action', () => {
       },
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'd97b3a3240' ? 'bad' : 'aaaa';
+      },
+    };
+
+    const contents = await fixture('docker-tree-sha.yaml');
+
+    expect(
+      await updateGitRefs(contents, mockGithubClientTreeSHA),
+    ).toMatchSnapshot();
+  });
+
+  it('handle docker tag with unknown commit', async () => {
+    const mockGithubClientTreeSHA: GitHubClient = {
+      async resolveRefToSHA({ ref }) {
+        if (ref === 'd97b3a3240') {
+          throw Error('unknown commit');
+        }
+        return ref === 'main' ? 'new' : ref;
+      },
+      async getTreeSHAForPath({ commitSHA }) {
+        return commitSHA === 'old' ? 'oldaaaa' : 'aaaa';
       },
     };
 


### PR DESCRIPTION
We only try to resolve the current `ref` and the commit found in the Docker tag as a heuristic to choose something other than the current commit SHA at the tracked ref that might be better and equivalent on the given subpath. So if either of them fail to resolve, we can ignore it rather than failing the whole update operation.

Fixes #40.