### PR TITLE
Performance improvements and API stats

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ author: 'Apollo GraphQL'
 
 # Define your inputs here.
 inputs:
+  api-cache:
+    description: 'Path to a file used to cache API calls (works well with actions/cache)'
+
   files:
     description: 'Glob pattern for files to search'
     required: true


### PR DESCRIPTION
- Don't use the GH API to map a commit SHA to itself
- Track GH API stats, print at end of execution
- Optional API cache file (designed for use with `actions/cache`). It caches tree SHA lookups, not ref lookups since refs may be mutable (but the other change in this PR reduces those too).
- Remove legacy `sanitized-promotion-target-regexp` output
- Set `suggested-promotion-branch-name` all the time, not just when there are some files.