### PR TITLE
Make logs better for parallelism

### DIFF
--- a/__tests__/update-docker-tags.test.ts
+++ b/__tests__/update-docker-tags.test.ts
@@ -2,6 +2,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { GetAllEquivalentTagsOptions } from '../src/artifactRegistry';
 import { updateDockerTags } from '../src/update-docker-tags';
+import { PrefixingLogger } from '../src/log';
 
 async function fixture(filename: string): Promise<string> {
   return await readFile(
@@ -39,11 +40,16 @@ describe('action', () => {
         );
       },
     };
-    const newContents = await updateDockerTags(contents, dockerRegistryClient);
+    const logger = PrefixingLogger.silent();
+    const newContents = await updateDockerTags(
+      contents,
+      dockerRegistryClient,
+      logger,
+    );
     expect(newContents).toMatchSnapshot();
 
     // It should be idempotent in this case.
-    expect(await updateDockerTags(contents, dockerRegistryClient)).toBe(
+    expect(await updateDockerTags(contents, dockerRegistryClient, logger)).toBe(
       newContents,
     );
   });

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -64,7 +64,7 @@ export class ArtifactRegistryDockerRegistryClient {
       tag,
     });
 
-    core.info(`Fetching tag ${tagPath}`);
+    core.info(`[AR API] Fetching tag ${tagPath}`);
     // Note: this throws if the repository or tag are not found.
     const { version } = (await this.client.getTag({ name: tagPath }))[0];
     if (!version) {
@@ -85,7 +85,7 @@ export class ArtifactRegistryDockerRegistryClient {
         docker_image: `${parsedVersion.package}@${parsedVersion.version}`,
       });
 
-    core.info(`Fetching Docker image ${dockerImagePath}`);
+    core.info(`[AR API] Fetching Docker image ${dockerImagePath}`);
     const { tags } = (
       await this.client.getDockerImage({ name: dockerImagePath })
     )[0];

--- a/src/github.ts
+++ b/src/github.ts
@@ -42,7 +42,7 @@ export class OctokitGitHubClient {
   constructor(private octokit: ReturnType<typeof getOctokit>) {}
 
   private logAPICall(name: string, description: string): void {
-    core.info(`GH API: ${name} ${description}`);
+    core.info(`[GH API] ${name} ${description}`);
     this.apiCalls.set(name, (this.apiCalls.get(name) ?? 0) + 1);
   }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,35 @@
+import * as core from '@actions/core';
+
+export class PrefixingLogger {
+  private silent = false;
+
+  constructor(private prefix = '') {}
+
+  static silent(): PrefixingLogger {
+    const logger = new PrefixingLogger();
+    logger.silent = true;
+    return logger;
+  }
+
+  info(message: string): void {
+    if (!this.silent) {
+      core.info(this.prefix + message);
+    }
+  }
+  warning(message: string): void {
+    if (!this.silent) {
+      core.warning(this.prefix + message);
+    }
+  }
+  error(message: string): void {
+    if (!this.silent) {
+      core.error(this.prefix + message);
+    }
+  }
+
+  withExtendedPrefix(extension: string): PrefixingLogger {
+    const logger = new PrefixingLogger(this.prefix + extension);
+    logger.silent = this.silent;
+    return logger;
+  }
+}

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,5 +1,4 @@
 import * as yaml from 'yaml';
-import * as core from '@actions/core';
 
 export type CSTScalarToken = yaml.CST.FlowScalar | yaml.CST.BlockScalar;
 
@@ -134,7 +133,6 @@ export function parseYAML(contents: string): {
   // we do that by writing to the CST node found in a `srcToken` reference.
   // Finally, when we're done, we stringify the CSTs (which have been mutated)
   // rather than the ASTs (via the `stringify` function we return).
-  core.info('Parsing');
   const topLevelTokens = [...new yaml.Parser().parse(contents)];
   const documents = [
     ...new yaml.Composer({ keepSourceTokens: true }).compose(topLevelTokens),
@@ -168,7 +166,6 @@ export function parseYAML(contents: string): {
   return {
     document,
     stringify() {
-      core.info('Stringifying');
       return topLevelTokens
         .map((topLevelToken) => yaml.CST.stringify(topLevelToken))
         .join('');


### PR DESCRIPTION
Replace the use of the GitHub Actions "group" feature with a lightweight logger that lets you add prefixes. So instead of needing an implicit group, you can just read the prefixes.

Also, run *all* files even if there are errors and show all errors at the end.

This also lets us turn off logging in tests.