### PR TITLE
[part 1] Include git messages in pr descriptions

### DIFF
--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -198,3 +198,9 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
     ]);
   });
 });
+
+describe('ArtifactRegistry.getRelevantCommits', () => {
+  it('should succeed', async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -29,7 +29,7 @@ function makePRTag(
 ): [string, DockerTag] {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
-  const shortHash = faker.git.shortSha();
+  const shortHash = faker.git.commitSha({ length: 7 });
   const hash = faker.git.commitSha();
 
   const prTag = `pr-123---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
@@ -51,7 +51,7 @@ function makeMainTag(
 ): [string, DockerTag] {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
-  const shortHash = faker.git.shortSha();
+  const shortHash = faker.git.commitSha({ length: 7 });
   const hash = faker.git.commitSha();
 
   const mainTag = `main---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
@@ -197,8 +197,8 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
     const [next, nextDockerTag] = makeMainTag(20, '2024', 4);
     const hash1 = faker.git.commitSha();
     const hash2 = faker.git.commitSha();
-    const shortHash1 = faker.git.shortSha();
-    const shortHash2 = faker.git.shortSha();
+    const shortHash1 = faker.git.commitSha({ length: 7 });
+    const shortHash2 = faker.git.commitSha({ length: 7 });
     const commit1First = makeDockerTag(
       EXAMPLE_TAG_NAME_PATH,
       6,
@@ -251,8 +251,6 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       commit2Second,
       commit1Third,
     ];
-
-    console.log(getAllHashes(tags));
 
     // We expect consecutive duplicate commit hashes to be deduped
     // However if it returns later, this could imply a revert or rollback.

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -52,7 +52,7 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
   it('should return nothing when given an empty list', async () => {
     const prev = makeMainTag(ENGINE_IDENTITY, 1, '2024', 4);
     const next = makeMainTag(ENGINE_IDENTITY, 2, '2024', 4);
-    expect(getTagsInRange(prev, next, [])).toStrictEqual([]);
+    expect(getTagsInRange(prev.version, next.version, [])).toStrictEqual([]);
   });
 
   it('should filter commits before prev (inclusive)', async () => {
@@ -64,7 +64,7 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       prev,
       makeMainTag(ENGINE_IDENTITY, 0, '2024', 4),
     ];
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
   });
 
   it('should filter commits after next (inclusive)', async () => {
@@ -76,7 +76,7 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       makeMainTag(ENGINE_IDENTITY, 12, '2024', 4),
       makeMainTag(ENGINE_IDENTITY, 100, '2024', 4),
     ];
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
   });
 
   it('should include commits between prev and next (in sorted order)', async () => {
@@ -88,7 +88,10 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
       makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3], tags[2]]);
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([
+      tags[3],
+      tags[2],
+    ]);
   });
 
   it('should return an empty list if left bound is not for `main---`', async () => {
@@ -100,7 +103,7 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
       makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
   });
 
   it('should return an empty list if right bound is not for `main---`', async () => {
@@ -112,7 +115,7 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
       makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
   });
 
   it('should ignore all tags without main--- prefix', async () => {
@@ -124,7 +127,9 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       makePRTag('123', ENGINE_IDENTITY, 7, '2024', 4),
       makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3]]);
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([
+      tags[3],
+    ]);
   });
 
   it('should dedup consecutive commit hashes', async () => {
@@ -185,7 +190,7 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
     // We expect consecutive duplicate commit hashes to be deduped
     // However if it returns later, this could imply a revert or rollback.
     // At the moment, we just keep that in, but later we should explicitly flag as a rollback.
-    expect(getTagsInRange(prev, next, tags)).toStrictEqual([
+    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([
       tags[2],
       tags[4],
       tags[5],

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { Tag, getTagsInRange } from '../src/artifactRegistry';
+import { DockerTag, getTagsInRange } from '../src/artifactRegistry';
 
 /**
  * Example tags from our registry:
@@ -13,7 +13,7 @@ function makeMainTag(
   count: number,
   year: string,
   month: number,
-): Tag {
+): DockerTag {
   const gitHash = faker.git.commitSha();
   return makeTag(`main`, name, count, year, month, gitHash);
 }
@@ -24,7 +24,7 @@ function makePRTag(
   count: number,
   year: string,
   month: number,
-): Tag {
+): DockerTag {
   const gitHash = faker.git.commitSha();
   return makeTag(`pr-${prNumber}`, name, count, year, month, gitHash);
 }
@@ -36,7 +36,7 @@ function makeTag(
   year: string,
   month: number,
   hash: string,
-): Tag {
+): DockerTag {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
 

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -126,4 +126,70 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3]]);
   });
+
+  it('should dedup consecutive commit hashes', async () => {
+    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 20, '2024', 4);
+    const commit1First = makeTag(
+      'main',
+      ENGINE_IDENTITY,
+      6,
+      '2024',
+      4,
+      'commit1hash',
+    );
+    const commit1Second = makeTag(
+      'main',
+      ENGINE_IDENTITY,
+      7,
+      '2024',
+      4,
+      'commit1hash',
+    );
+    const commit1Third = makeTag(
+      'main',
+      ENGINE_IDENTITY,
+      11,
+      '2024',
+      4,
+      'commit1hash',
+    );
+    const commit2First = makeTag(
+      'main',
+      ENGINE_IDENTITY,
+      9,
+      '2024',
+      4,
+      'commit2hash',
+    );
+    const commit2Second = makeTag(
+      'main',
+      ENGINE_IDENTITY,
+      10,
+      '2024',
+      4,
+      'commit2hash',
+    );
+
+    const tags = [
+      prev,
+      next,
+      commit1First,
+      commit1Second,
+      makeMainTag(ENGINE_IDENTITY, 8, '2024', 4),
+      commit2First,
+      commit2Second,
+      commit1Third,
+    ];
+
+    // We expect consecutive duplicate commit hashes to be deduped
+    // However if it returns later, this could imply a revert or rollback.
+    // At the moment, we just keep that in, but later we should explicitly flag as a rollback.
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([
+      tags[2],
+      tags[4],
+      tags[5],
+      tags[7],
+    ]);
+  });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -1,6 +1,13 @@
 import { faker } from '@faker-js/faker';
-import { Tag, getCommitsBetweenTags } from '../src/artifactRegistry';
+import { Tag, getTagsInRange } from '../src/artifactRegistry';
 
+/**
+ * Example tags from our registry:
+ *
+ * pr-15028---0013576-2024.04-gabcdefge979bd9243574e44a63a73b0f4e12ede56
+ * main---0013572-2024.04-gabcdefg4d7f58193abc9e24a476133a771ca979c2
+ *
+ */
 function makeTag(
   name: string,
   count: number,
@@ -13,14 +20,52 @@ function makeTag(
   const gitHash = faker.git.commitSha();
   return {
     name,
-    version: `main---${paddedCount}-${year}.${paddedMonth}-${gitHash}`,
+    version: `main---${paddedCount}-${year}.${paddedMonth}-g${gitHash}`,
   };
 }
 
+const ENGINE_IDENTITY = 'engine-identity';
+
 describe('ArtifactRegistry._getCommitsBetweenTags', () => {
   it('should return nothing when given an empty list', async () => {
-    const prev = makeTag('name', 1, '2024', 4);
-    const next = makeTag('name', 2, '2024', 4);
-    expect(getCommitsBetweenTags(prev, next, [])).toStrictEqual([]);
+    const prev = makeTag(ENGINE_IDENTITY, 1, '2024', 4);
+    const next = makeTag(ENGINE_IDENTITY, 2, '2024', 4);
+    expect(getTagsInRange(prev, next, [])).toStrictEqual([]);
+  });
+
+  it('should filter commits before prev (inclusive)', async () => {
+    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const tags = [
+      makeTag(ENGINE_IDENTITY, 4, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 3, '2024', 4),
+      prev,
+      makeTag(ENGINE_IDENTITY, 0, '2024', 4),
+    ];
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+  });
+
+  it('should filter commits after next (inclusive)', async () => {
+    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const tags = [
+      next,
+      makeTag(ENGINE_IDENTITY, 11, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 12, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 100, '2024', 4),
+    ];
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+  });
+
+  it('should include commits between prev and next (in sorted order)', async () => {
+    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const tags = [
+      prev,
+      next,
+      makeTag(ENGINE_IDENTITY, 7, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+    ];
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3], tags[2]]);
   });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -109,4 +109,16 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
   });
+
+  it('should ignore all tags without main--- prefix', async () => {
+    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const tags = [
+      prev,
+      next,
+      makePRTag('123', ENGINE_IDENTITY, 7, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+    ];
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3]]);
+  });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -24,6 +24,23 @@ function makeTag(
   };
 }
 
+function makePRTag(
+  prNumber: string,
+  name: string,
+  count: number,
+  year: string,
+  month: number,
+): Tag {
+  const paddedCount = count.toString().padStart(7, '0');
+  const paddedMonth = month.toString().padStart(2, '0');
+
+  const gitHash = faker.git.commitSha();
+  return {
+    name,
+    version: `pr-${prNumber}---${paddedCount}-${year}.${paddedMonth}-g${gitHash}`,
+  };
+}
+
 const ENGINE_IDENTITY = 'engine-identity';
 
 describe('ArtifactRegistry._getCommitsBetweenTags', () => {
@@ -67,5 +84,29 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
       makeTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3], tags[2]]);
+  });
+
+  it('should return an empty list if left bound is not for `main---`', async () => {
+    const prev = makePRTag('123', ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const tags = [
+      prev,
+      next,
+      makeTag(ENGINE_IDENTITY, 7, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+    ];
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
+  });
+
+  it('should return an empty list if right bound is not for `main---`', async () => {
+    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makePRTag('123', ENGINE_IDENTITY, 10, '2024', 4);
+    const tags = [
+      prev,
+      next,
+      makeTag(ENGINE_IDENTITY, 7, '2024', 4),
+      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+    ];
+    expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
   });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { DockerTag, getTagsInRange } from '../src/artifactRegistry';
+import { DockerTag, getRelevantCommits } from '../src/artifactRegistry';
 
 /**
  * Example tags from our registry:
@@ -8,180 +8,184 @@ import { DockerTag, getTagsInRange } from '../src/artifactRegistry';
  * main---0013572-2024.04-gabcdefg4d7f58193abc9e24a476133a771ca979c2
  *
  */
-function makeMainTag(
-  name: string,
-  count: number,
-  year: string,
-  month: number,
-): DockerTag {
-  const gitHash = faker.git.commitSha();
-  return makeTag(`main`, name, count, year, month, gitHash);
+
+function stubDockerTag(count: number, year: string, month: number): DockerTag {
+  const shortHash = faker.git.commitSha();
+  const hash = faker.git.commitSha();
+  return makeDockerTag(
+    EXAMPLE_TAG_NAME_PATH,
+    count,
+    year,
+    month,
+    hash,
+    shortHash,
+  );
 }
 
-function makePRTag(
-  prNumber: string,
-  name: string,
-  count: number,
-  year: string,
-  month: number,
-): DockerTag {
-  const gitHash = faker.git.commitSha();
-  return makeTag(`pr-${prNumber}`, name, count, year, month, gitHash);
+function makePRTag(count: number, year: string, month: number): string {
+  const paddedCount = count.toString().padStart(7, '0');
+  const paddedMonth = month.toString().padStart(2, '0');
+
+  return `pr-123---${paddedCount}-${year}.${paddedMonth}-g${faker.git.commitSha()}`;
 }
 
-function makeTag(
-  prefix: string,
-  name: string,
+function makeMainTag(count: number, year: string, month: number): string {
+  const paddedCount = count.toString().padStart(7, '0');
+  const paddedMonth = month.toString().padStart(2, '0');
+
+  return `main---${paddedCount}-${year}.${paddedMonth}-g${faker.git.commitSha()}`;
+}
+
+function makeDockerTag(
+  namePathPrefix: string,
   count: number,
   year: string,
   month: number,
   hash: string,
+  shortHash: string,
 ): DockerTag {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
 
   return {
-    name,
-    version: `${prefix}---${paddedCount}-${year}.${paddedMonth}-g${hash}`,
+    name: `${namePathPrefix}/tags/${year}.${paddedMonth}-${paddedCount}-g${shortHash}`,
+    version: `${namePathPrefix}/versions/sha256:${hash}`,
   };
 }
 
-const ENGINE_IDENTITY = 'engine-identity';
+function getTagFromDockerTagName(dockerTagName: string): string {
+  return dockerTagName.split('/').pop() as string;
+}
 
-describe('ArtifactRegistry._getCommitsBetweenTags', () => {
+const EXAMPLE_TAG_NAME_PATH =
+  'projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/example';
+
+describe('ArtifactRegistry.getRelevantCommits', () => {
   it('should return nothing when given an empty list', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 1, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 2, '2024', 4);
-    expect(getTagsInRange(prev.version, next.version, [])).toStrictEqual([]);
+    const prev = makeMainTag(1, '2024', 4);
+    const next = makeMainTag(2, '2024', 4);
+    expect(
+      getRelevantCommits(prev, next, [], getTagFromDockerTagName),
+    ).toStrictEqual([]);
   });
 
   it('should filter commits before prev (inclusive)', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(5, '2024', 4);
+    const next = makeMainTag(10, '2024', 4);
     const tags = [
-      makeMainTag(ENGINE_IDENTITY, 4, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 3, '2024', 4),
-      prev,
-      makeMainTag(ENGINE_IDENTITY, 0, '2024', 4),
+      stubDockerTag(4, '2024', 4),
+      stubDockerTag(5, '2024', 4),
+      stubDockerTag(3, '2024', 4),
+      stubDockerTag(0, '2024', 4),
     ];
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
+    expect(
+      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
+    ).toStrictEqual([]);
   });
 
   it('should filter commits after next (inclusive)', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(5, '2024', 4);
+    const next = makeMainTag(10, '2024', 4);
     const tags = [
-      next,
-      makeMainTag(ENGINE_IDENTITY, 11, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 12, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 100, '2024', 4),
+      stubDockerTag(10, '2024', 4),
+      stubDockerTag(11, '2024', 4),
+      stubDockerTag(12, '2024', 4),
+      stubDockerTag(100, '2024', 4),
     ];
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
+    expect(
+      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
+    ).toStrictEqual([]);
   });
 
   it('should include commits between prev and next (in sorted order)', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(5, '2024', 4);
+    const next = makeMainTag(10, '2024', 4);
     const tags = [
-      prev,
-      next,
-      makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
+      stubDockerTag(5, '2024', 4),
+      stubDockerTag(10, '2024', 4),
+      stubDockerTag(7, '2024', 4),
+      stubDockerTag(6, '2024', 4),
     ];
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([
-      tags[3],
-      tags[2],
-    ]);
+    expect(
+      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
+    ).toStrictEqual([tags[3], tags[2]]);
   });
 
   it('should return an empty list if left bound is not for `main---`', async () => {
-    const prev = makePRTag('123', ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makePRTag(5, '2024', 4);
+    const next = makeMainTag(10, '2024', 4);
     const tags = [
-      prev,
-      next,
-      makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
+      stubDockerTag(5, '2024', 4),
+      stubDockerTag(10, '2024', 4),
+      stubDockerTag(7, '2024', 4),
+      stubDockerTag(6, '2024', 4),
     ];
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
+    expect(
+      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
+    ).toStrictEqual([]);
   });
 
   it('should return an empty list if right bound is not for `main---`', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makePRTag('123', ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(5, '2024', 4);
+    const next = makePRTag(10, '2024', 4);
     const tags = [
-      prev,
-      next,
-      makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
+      stubDockerTag(5, '2024', 4),
+      stubDockerTag(10, '2024', 4),
+      stubDockerTag(7, '2024', 4),
+      stubDockerTag(6, '2024', 4),
     ];
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([]);
-  });
-
-  it('should ignore all tags without main--- prefix', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
-    const tags = [
-      prev,
-      next,
-      makePRTag('123', ENGINE_IDENTITY, 7, '2024', 4),
-      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
-    ];
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([
-      tags[3],
-    ]);
+    expect(
+      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
+    ).toStrictEqual([]);
   });
 
   it('should dedup consecutive commit hashes', async () => {
-    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeMainTag(ENGINE_IDENTITY, 20, '2024', 4);
-    const commit1First = makeTag(
-      'main',
-      ENGINE_IDENTITY,
+    const prev = makeMainTag(5, '2024', 4);
+    const next = makeMainTag(20, '2024', 4);
+    const hash1 = faker.git.commitSha();
+    const hash2 = faker.git.commitSha();
+    const shortHash1 = faker.git.shortSha();
+    const shortHash2 = faker.git.shortSha();
+    const commit1First = makeDockerTag(
+      EXAMPLE_TAG_NAME_PATH,
       6,
       '2024',
       4,
-      'commit1hash',
+      hash1,
+      shortHash1,
     );
-    const commit1Second = makeTag(
+    const commit1Second = makeDockerTag(
       'main',
-      ENGINE_IDENTITY,
       7,
       '2024',
       4,
-      'commit1hash',
+      hash1,
+      shortHash1,
     );
-    const commit1Third = makeTag(
+    const commit1Third = makeDockerTag(
       'main',
-      ENGINE_IDENTITY,
       11,
       '2024',
       4,
-      'commit1hash',
+      hash1,
+      shortHash1,
     );
-    const commit2First = makeTag(
+    const commit2First = makeDockerTag('main', 9, '2024', 4, hash2, shortHash2);
+    const commit2Second = makeDockerTag(
       'main',
-      ENGINE_IDENTITY,
-      9,
-      '2024',
-      4,
-      'commit2hash',
-    );
-    const commit2Second = makeTag(
-      'main',
-      ENGINE_IDENTITY,
       10,
       '2024',
       4,
-      'commit2hash',
+      hash2,
+      shortHash2,
     );
 
     const tags = [
-      prev,
-      next,
+      stubDockerTag(5, '2024', 4),
+      stubDockerTag(20, '2024', 4),
       commit1First,
       commit1Second,
-      makeMainTag(ENGINE_IDENTITY, 8, '2024', 4),
+      stubDockerTag(8, '2024', 4),
       commit2First,
       commit2Second,
       commit1Third,
@@ -190,17 +194,8 @@ describe('ArtifactRegistry._getCommitsBetweenTags', () => {
     // We expect consecutive duplicate commit hashes to be deduped
     // However if it returns later, this could imply a revert or rollback.
     // At the moment, we just keep that in, but later we should explicitly flag as a rollback.
-    expect(getTagsInRange(prev.version, next.version, tags)).toStrictEqual([
-      tags[2],
-      tags[4],
-      tags[5],
-      tags[7],
-    ]);
-  });
-});
-
-describe('ArtifactRegistry.getRelevantCommits', () => {
-  it('should succeed', async () => {
-    expect(true).toBe(true);
+    expect(
+      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
+    ).toStrictEqual([tags[2], tags[4], tags[5], tags[7]]);
   });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -22,18 +22,60 @@ function stubDockerTag(count: number, year: string, month: number): DockerTag {
   );
 }
 
-function makePRTag(count: number, year: string, month: number): string {
+function makePRTag(
+  count: number,
+  year: string,
+  month: number,
+): [string, DockerTag] {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
+  const shortHash = faker.git.shortSha();
+  const hash = faker.git.commitSha();
 
-  return `pr-123---${paddedCount}-${year}.${paddedMonth}-g${faker.git.commitSha()}`;
+  const prTag = `pr-123---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
+  const dockerTag = makeDockerTag(
+    EXAMPLE_TAG_NAME_PATH,
+    count,
+    year,
+    month,
+    hash,
+    shortHash,
+  );
+  return [prTag, dockerTag];
 }
 
-function makeMainTag(count: number, year: string, month: number): string {
+function makeMainTag(
+  count: number,
+  year: string,
+  month: number,
+): [string, DockerTag] {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
+  const shortHash = faker.git.shortSha();
+  const hash = faker.git.commitSha();
 
-  return `main---${paddedCount}-${year}.${paddedMonth}-g${faker.git.commitSha()}`;
+  const mainTag = `main---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
+  const dockerTag = makeDockerTag(
+    EXAMPLE_TAG_NAME_PATH,
+    count,
+    year,
+    month,
+    hash,
+    shortHash,
+  );
+  return [mainTag, dockerTag];
+}
+
+function getHash(dockerTag: DockerTag): string {
+  const gitCommitMatches = dockerTag.version.match(/sha256:([0-9a-fA-F]+)$/);
+  if (!gitCommitMatches) {
+    throw new Error(`Could not find git commit in ${dockerTag.version}`);
+  }
+  return gitCommitMatches[1];
+}
+
+function getAllHashes(tags: DockerTag[]): string[] {
+  return tags.map(getHash);
 }
 
 function makeDockerTag(
@@ -48,13 +90,22 @@ function makeDockerTag(
   const paddedMonth = month.toString().padStart(2, '0');
 
   return {
-    name: `${namePathPrefix}/tags/${year}.${paddedMonth}-${paddedCount}-g${shortHash}`,
+    name: `${namePathPrefix}/tags/${paddedCount}-${year}.${paddedMonth}-g${shortHash}`,
     version: `${namePathPrefix}/versions/sha256:${hash}`,
   };
 }
 
-function getTagFromDockerTagName(dockerTagName: string): string {
-  return dockerTagName.split('/').pop() as string;
+/**
+ * transforming the tag into the `main---count-year.month-ggitCommitHash` format
+ */
+function getTagFromDockerTagName(dockerTag: DockerTag): string {
+  const gitCommitMatches = dockerTag.version.match(/sha256:([0-9a-fA-F]+)$/);
+  if (!gitCommitMatches) {
+    throw new Error(`Could not find git commit in ${dockerTag.version}`);
+  }
+  const nameTagData = dockerTag.name.split('/').pop() as string;
+  const withoutHash = nameTagData.split('-').slice(0, 2).join('-');
+  return `main---${withoutHash}-g${gitCommitMatches[1]}`;
 }
 
 const EXAMPLE_TAG_NAME_PATH =
@@ -62,19 +113,19 @@ const EXAMPLE_TAG_NAME_PATH =
 
 describe('ArtifactRegistry.getRelevantCommits', () => {
   it('should return nothing when given an empty list', async () => {
-    const prev = makeMainTag(1, '2024', 4);
-    const next = makeMainTag(2, '2024', 4);
+    const [prev] = makeMainTag(1, '2024', 4);
+    const [next] = makeMainTag(2, '2024', 4);
     expect(
       getRelevantCommits(prev, next, [], getTagFromDockerTagName),
     ).toStrictEqual([]);
   });
 
   it('should filter commits before prev (inclusive)', async () => {
-    const prev = makeMainTag(5, '2024', 4);
-    const next = makeMainTag(10, '2024', 4);
+    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
+    const [next] = makeMainTag(10, '2024', 4);
     const tags = [
+      prevDockerTag,
       stubDockerTag(4, '2024', 4),
-      stubDockerTag(5, '2024', 4),
       stubDockerTag(3, '2024', 4),
       stubDockerTag(0, '2024', 4),
     ];
@@ -84,10 +135,10 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should filter commits after next (inclusive)', async () => {
-    const prev = makeMainTag(5, '2024', 4);
-    const next = makeMainTag(10, '2024', 4);
+    const [prev] = makeMainTag(5, '2024', 4);
+    const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
     const tags = [
-      stubDockerTag(10, '2024', 4),
+      nextDockerTag,
       stubDockerTag(11, '2024', 4),
       stubDockerTag(12, '2024', 4),
       stubDockerTag(100, '2024', 4),
@@ -98,25 +149,27 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should include commits between prev and next (in sorted order)', async () => {
-    const prev = makeMainTag(5, '2024', 4);
-    const next = makeMainTag(10, '2024', 4);
+    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
+    const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
     const tags = [
-      stubDockerTag(5, '2024', 4),
-      stubDockerTag(10, '2024', 4),
+      prevDockerTag,
+      nextDockerTag,
       stubDockerTag(7, '2024', 4),
       stubDockerTag(6, '2024', 4),
     ];
+
+    const expected = getAllHashes([tags[3], tags[2]]);
     expect(
       getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual([tags[3], tags[2]]);
+    ).toStrictEqual(expected);
   });
 
   it('should return an empty list if left bound is not for `main---`', async () => {
-    const prev = makePRTag(5, '2024', 4);
-    const next = makeMainTag(10, '2024', 4);
+    const [prev, prevDockerTag] = makePRTag(5, '2024', 4);
+    const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
     const tags = [
-      stubDockerTag(5, '2024', 4),
-      stubDockerTag(10, '2024', 4),
+      prevDockerTag,
+      nextDockerTag,
       stubDockerTag(7, '2024', 4),
       stubDockerTag(6, '2024', 4),
     ];
@@ -126,11 +179,11 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should return an empty list if right bound is not for `main---`', async () => {
-    const prev = makeMainTag(5, '2024', 4);
-    const next = makePRTag(10, '2024', 4);
+    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
+    const [next, nextDockerTag] = makePRTag(10, '2024', 4);
     const tags = [
-      stubDockerTag(5, '2024', 4),
-      stubDockerTag(10, '2024', 4),
+      prevDockerTag,
+      nextDockerTag,
       stubDockerTag(7, '2024', 4),
       stubDockerTag(6, '2024', 4),
     ];
@@ -140,8 +193,8 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should dedup consecutive commit hashes', async () => {
-    const prev = makeMainTag(5, '2024', 4);
-    const next = makeMainTag(20, '2024', 4);
+    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
+    const [next, nextDockerTag] = makeMainTag(20, '2024', 4);
     const hash1 = faker.git.commitSha();
     const hash2 = faker.git.commitSha();
     const shortHash1 = faker.git.shortSha();
@@ -155,22 +208,22 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       shortHash1,
     );
     const commit1Second = makeDockerTag(
-      'main',
+      EXAMPLE_TAG_NAME_PATH,
       7,
       '2024',
       4,
       hash1,
       shortHash1,
     );
-    const commit1Third = makeDockerTag(
-      'main',
-      11,
+    const otherCommit = stubDockerTag(8, '2024', 4);
+    const commit2First = makeDockerTag(
+      EXAMPLE_TAG_NAME_PATH,
+      9,
       '2024',
       4,
-      hash1,
-      shortHash1,
+      hash2,
+      shortHash2,
     );
-    const commit2First = makeDockerTag('main', 9, '2024', 4, hash2, shortHash2);
     const commit2Second = makeDockerTag(
       'main',
       10,
@@ -179,23 +232,34 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       hash2,
       shortHash2,
     );
+    const commit1Third = makeDockerTag(
+      EXAMPLE_TAG_NAME_PATH,
+      11,
+      '2024',
+      4,
+      hash1,
+      shortHash1,
+    );
 
     const tags = [
-      stubDockerTag(5, '2024', 4),
-      stubDockerTag(20, '2024', 4),
+      prevDockerTag,
+      nextDockerTag,
       commit1First,
       commit1Second,
-      stubDockerTag(8, '2024', 4),
+      otherCommit,
       commit2First,
       commit2Second,
       commit1Third,
     ];
 
+    console.log(getAllHashes(tags));
+
     // We expect consecutive duplicate commit hashes to be deduped
     // However if it returns later, this could imply a revert or rollback.
     // At the moment, we just keep that in, but later we should explicitly flag as a rollback.
+    const expected = getAllHashes([tags[2], tags[4], tags[5], tags[7]]);
     expect(
       getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual([tags[2], tags[4], tags[5], tags[7]]);
+    ).toStrictEqual(expected);
   });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -8,20 +8,14 @@ import { Tag, getTagsInRange } from '../src/artifactRegistry';
  * main---0013572-2024.04-gabcdefg4d7f58193abc9e24a476133a771ca979c2
  *
  */
-function makeTag(
+function makeMainTag(
   name: string,
   count: number,
   year: string,
   month: number,
 ): Tag {
-  const paddedCount = count.toString().padStart(7, '0');
-  const paddedMonth = month.toString().padStart(2, '0');
-
   const gitHash = faker.git.commitSha();
-  return {
-    name,
-    version: `main---${paddedCount}-${year}.${paddedMonth}-g${gitHash}`,
-  };
+  return makeTag(`main`, name, count, year, month, gitHash);
 }
 
 function makePRTag(
@@ -31,13 +25,24 @@ function makePRTag(
   year: string,
   month: number,
 ): Tag {
+  const gitHash = faker.git.commitSha();
+  return makeTag(`pr-${prNumber}`, name, count, year, month, gitHash);
+}
+
+function makeTag(
+  prefix: string,
+  name: string,
+  count: number,
+  year: string,
+  month: number,
+  hash: string,
+): Tag {
   const paddedCount = count.toString().padStart(7, '0');
   const paddedMonth = month.toString().padStart(2, '0');
 
-  const gitHash = faker.git.commitSha();
   return {
     name,
-    version: `pr-${prNumber}---${paddedCount}-${year}.${paddedMonth}-g${gitHash}`,
+    version: `${prefix}---${paddedCount}-${year}.${paddedMonth}-g${hash}`,
   };
 }
 
@@ -45,79 +50,79 @@ const ENGINE_IDENTITY = 'engine-identity';
 
 describe('ArtifactRegistry._getCommitsBetweenTags', () => {
   it('should return nothing when given an empty list', async () => {
-    const prev = makeTag(ENGINE_IDENTITY, 1, '2024', 4);
-    const next = makeTag(ENGINE_IDENTITY, 2, '2024', 4);
+    const prev = makeMainTag(ENGINE_IDENTITY, 1, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 2, '2024', 4);
     expect(getTagsInRange(prev, next, [])).toStrictEqual([]);
   });
 
   it('should filter commits before prev (inclusive)', async () => {
-    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
     const tags = [
-      makeTag(ENGINE_IDENTITY, 4, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 3, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 4, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 3, '2024', 4),
       prev,
-      makeTag(ENGINE_IDENTITY, 0, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 0, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should filter commits after next (inclusive)', async () => {
-    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
     const tags = [
       next,
-      makeTag(ENGINE_IDENTITY, 11, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 12, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 100, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 11, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 12, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 100, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should include commits between prev and next (in sorted order)', async () => {
-    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
     const tags = [
       prev,
       next,
-      makeTag(ENGINE_IDENTITY, 7, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3], tags[2]]);
   });
 
   it('should return an empty list if left bound is not for `main---`', async () => {
     const prev = makePRTag('123', ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
     const tags = [
       prev,
       next,
-      makeTag(ENGINE_IDENTITY, 7, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should return an empty list if right bound is not for `main---`', async () => {
-    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
     const next = makePRTag('123', ENGINE_IDENTITY, 10, '2024', 4);
     const tags = [
       prev,
       next,
-      makeTag(ENGINE_IDENTITY, 7, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 7, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should ignore all tags without main--- prefix', async () => {
-    const prev = makeTag(ENGINE_IDENTITY, 5, '2024', 4);
-    const next = makeTag(ENGINE_IDENTITY, 10, '2024', 4);
+    const prev = makeMainTag(ENGINE_IDENTITY, 5, '2024', 4);
+    const next = makeMainTag(ENGINE_IDENTITY, 10, '2024', 4);
     const tags = [
       prev,
       next,
       makePRTag('123', ENGINE_IDENTITY, 7, '2024', 4),
-      makeTag(ENGINE_IDENTITY, 6, '2024', 4),
+      makeMainTag(ENGINE_IDENTITY, 6, '2024', 4),
     ];
     expect(getTagsInRange(prev, next, tags)).toStrictEqual([tags[3]]);
   });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -1,0 +1,26 @@
+import { faker } from '@faker-js/faker';
+import { Tag, getCommitsBetweenTags } from '../src/artifactRegistry';
+
+function makeTag(
+  name: string,
+  count: number,
+  year: string,
+  month: number,
+): Tag {
+  const paddedCount = count.toString().padStart(7, '0');
+  const paddedMonth = month.toString().padStart(2, '0');
+
+  const gitHash = faker.git.commitSha();
+  return {
+    name,
+    version: `main---${paddedCount}-${year}.${paddedMonth}-${gitHash}`,
+  };
+}
+
+describe('ArtifactRegistry._getCommitsBetweenTags', () => {
+  it('should return nothing when given an empty list', async () => {
+    const prev = makeTag('name', 1, '2024', 4);
+    const next = makeTag('name', 2, '2024', 4);
+    expect(getCommitsBetweenTags(prev, next, [])).toStrictEqual([]);
+  });
+});

--- a/__tests__/caching.test.ts
+++ b/__tests__/caching.test.ts
@@ -9,6 +9,9 @@ describe('CachingDockerRegistryClient caches', () => {
       async getAllEquivalentTags() {
         return [(++call).toString()];
       },
+      async getGitCommitsBetweenTags() {
+        return [];
+      },
     });
 
     async function exp(

--- a/__tests__/caching.test.ts
+++ b/__tests__/caching.test.ts
@@ -44,6 +44,9 @@ describe('CachingGitHubClient caches', () => {
       async getTreeSHAForPath() {
         return '';
       },
+      async compareCommits() {
+        return null;
+      },
     });
 
     async function exp(
@@ -74,6 +77,9 @@ describe('CachingGitHubClient caches', () => {
       },
       async getTreeSHAForPath() {
         return (++call).toString();
+      },
+      async compareCommits() {
+        return null;
       },
     });
 

--- a/__tests__/update-docker-tags.test.ts
+++ b/__tests__/update-docker-tags.test.ts
@@ -39,6 +39,9 @@ describe('action', () => {
           }[tag] ?? []
         );
       },
+      async getGitCommitsBetweenTags() {
+        return [];
+      },
     };
     const logger = PrefixingLogger.silent();
     const newContents = await updateDockerTags(

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -14,6 +14,9 @@ const mockGitHubClient: GitHubClient = {
   async getTreeSHAForPath() {
     return `${Math.random()}`;
   },
+  async compareCommits() {
+    return null;
+  },
 };
 
 const logger = PrefixingLogger.silent();
@@ -53,6 +56,9 @@ describe('action', () => {
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'old' ? 'aaaa' : treeSHAForNew;
       },
+      async compareCommits() {
+        return null;
+      },
     };
 
     const contents = await fixture('tree-sha.yaml');
@@ -80,6 +86,9 @@ describe('action', () => {
       async getTreeSHAForPath() {
         return 'aaaa';
       },
+      async compareCommits() {
+        return null;
+      },
     };
 
     const contents = await fixture('tree-sha.yaml');
@@ -96,6 +105,9 @@ describe('action', () => {
       },
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'd97b3a3240' ? 'bad' : 'aaaa';
+      },
+      async compareCommits() {
+        return null;
       },
     };
 
@@ -116,6 +128,9 @@ describe('action', () => {
       },
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'old' ? 'oldaaaa' : 'aaaa';
+      },
+      async compareCommits() {
+        return null;
       },
     };
 

--- a/__tests__/update-promoted-values.test.ts
+++ b/__tests__/update-promoted-values.test.ts
@@ -15,23 +15,22 @@ const logger = PrefixingLogger.silent();
 describe('action', () => {
   it('updates git refs', async () => {
     const contents = await fixture('sample.yaml');
-    const newContents = await updatePromotedValues(contents, 'prod', logger);
+    const [newContents] = await updatePromotedValues(contents, 'prod', logger);
     expect(newContents).toMatchSnapshot();
 
     // It should be idempotent in this case.
-    expect(await updatePromotedValues(newContents, 'prod', logger)).toBe(
-      newContents,
-    );
+    const [actual] = await updatePromotedValues(newContents, 'prod', logger);
+    expect(actual).toBe(newContents);
   });
 
   it('respects defaults and explicit specifications for yamlPaths', async () => {
-    expect(
-      await updatePromotedValues(
-        await fixture('yaml-paths-defaults.yaml'),
-        null,
-        logger,
-      ),
-    ).toMatchSnapshot();
+    const [actual] = await updatePromotedValues(
+      await fixture('yaml-paths-defaults.yaml'),
+      null,
+      logger,
+    );
+
+    expect(actual).toMatchSnapshot();
   });
 
   it('throws if no default yamlPaths entry works', async () => {

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ outputs:
   is-migration:
     description: 'If the promotion is for running DB migrations'
 
+  relevant-commits:
+    description: 'A map of relevant commits for service names as JSON'
+
 runs:
   using: node20
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "yaml": "^2.3.4"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@types/async": "3.2.24",
         "@types/jest": "29.5.12",
         "@types/lodash": "4.17.0",
@@ -856,6 +857,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@fastify/busboy": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "yaml": "^2.3.4"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@types/async": "3.2.24",
     "@types/jest": "29.5.12",
     "@types/lodash": "4.17.0",

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -221,11 +221,11 @@ export function getTagsInRange(
     })
     .filter((tag) => isMainVersion(tag.version));
 
-  const res = dtedupNeighboringTags(tagsAfterInitialFilters);
+  const res = dedupNeighboringTags(tagsAfterInitialFilters);
   return res;
 }
 
-function isMsainVersion(version: string): boolean {
+function isMainVersion(version: string): boolean {
   return version.startsWith('main---');
 }
 

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -268,6 +268,24 @@ function dedupNeighboringTags(tags: Tag[]): Tag[] {
   return res;
 }
 
+/**
+ * getRelevantCommits
+ *
+ * @param {string} prevTag
+ *   The previous docker tag: of the following format: main---0013567-2024.04-g<githash>
+ * @param {string} nextTag
+ *  The next docker tag: main---0013567-2024.04-g<githash>
+ *
+ * @param {Tag[]} dockerTags
+ *  The docker tags as we need to parse and filter into relevant commits. Provided by a previous call to the artifact registry.
+ *
+ *
+ * @param {function} getTagFromDockerTagName
+ *   Should map from `projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/servicename/tags/2022.02-278-g123456789` -> `2022.02-278-g123456789`
+ *   Should be a wrapper around the ArtifactRegistryClient, but written this way for testability, so the behavior can be injected.
+ *
+ * @returns {string[]} - The relevant commits as strings
+ */
 function getRelevantCommits(
   prevTag: string,
   nextTag: string,

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -240,10 +240,17 @@ export type Tag = {
 };
 
 export function getTagsInRange(prevTag: Tag, nextTag: Tag, tags: Tag[]): Tag[] {
+  if (!(isMainTag(prevTag) && isMainTag(nextTag))) {
+    return [];
+  }
+
   const sortedTags = [...tags].sort((a, b) => (a.version > b.version ? 1 : -1));
   const res = sortedTags.filter((tag) => {
     return tag.version > prevTag.version && tag.version < nextTag.version;
   });
-  console.log(res);
   return res;
+}
+
+function isMainTag(tag: Tag): boolean {
+  return tag.version.startsWith('main---');
 }

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -100,6 +100,8 @@ export class ArtifactRegistryDockerRegistryClient {
     const tags = dockerTags
       .filter((tag) => tag.version && tag.name)
       .map((tag) => {
+        core.info('Tag in map');
+        core.info(JSON.stringify(tag));
         const { tagVersion } = this.client.pathTemplates.tagPathTemplate.match(
           tag.name as string,
         );

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -245,9 +245,11 @@ export function getTagsInRange(prevTag: Tag, nextTag: Tag, tags: Tag[]): Tag[] {
   }
 
   const sortedTags = [...tags].sort((a, b) => (a.version > b.version ? 1 : -1));
-  const res = sortedTags.filter((tag) => {
-    return tag.version > prevTag.version && tag.version < nextTag.version;
-  });
+  const res = sortedTags
+    .filter((tag) => {
+      return tag.version > prevTag.version && tag.version < nextTag.version;
+    })
+    .filter((tag) => isMainTag(tag));
   return res;
 }
 

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -85,6 +85,7 @@ export class ArtifactRegistryDockerRegistryClient {
         }),
       })
     )[0];
+    core.info(`Docker Tags ${Array.from(dockerTags).join(', ')}`);
 
     // We are going to get all of the relevant tags with unique hashes.
 
@@ -102,11 +103,14 @@ export class ArtifactRegistryDockerRegistryClient {
         return { name: tag.name as string, version: tagVersion as string };
       });
 
+    core.info(`Step1 Tags ${Array.from(tags).join(', ')}`);
+
     const relevantCommits: string[] = getTagsInRange(
       prevTag,
       nextTag,
       tags,
     ).map(getTagCommitHash);
+
     core.info(`Relevant Commits ${Array.from(relevantCommits).join(', ')}`);
 
     return relevantCommits;

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -294,7 +294,7 @@ function dedupNeighboringTags(tags: DockerTag[]): DockerTag[] {
  *
  * @returns {string[]} - The relevant commits as strings
  */
-function getRelevantCommits(
+export function getRelevantCommits(
   prevTag: string,
   nextTag: string,
   dockerTags: DockerTag[],
@@ -311,9 +311,11 @@ function getRelevantCommits(
     if (!dockerTag.version || !dockerTag.name) continue;
 
     const tag = getTagFromDockerTagName(dockerTag.name);
+    core.info(`Tag: ${tag}`);
 
     // We only care about the tags between prev and next that have a git commit
     const gitCommitMatches = tag.match(/-g([0-9a-fA-F]+)$/);
+    core.info(`hash: ${gitCommitMatches}`);
     if (
       ((tag >= prevTag && tag <= nextTag) ||
         (tag <= prevTag && tag >= nextTag)) &&

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -77,6 +77,11 @@ export class ArtifactRegistryDockerRegistryClient {
     // Note: we don't need `listTagsAsync` (which is recommended) because we
     // only care about the first element in the result array, which is the list of tags.
     // https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#auto-pagination
+    // These tags look like the following:
+    // {
+    //   "name":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/tags/2022.02-278-g16607e3143",
+    //   "version":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/versions/sha256:ef8b944a2c6fc5e20b3df6a1500292cf65e28039f3daa8a6df55b84c5eaaecca"
+    // }
     const dockerTags = (
       await this.client.listTags({
         parent: this.client.pathTemplates.packagePathTemplate.render({
@@ -98,6 +103,10 @@ export class ArtifactRegistryDockerRegistryClient {
         const { tagVersion } = this.client.pathTemplates.tagPathTemplate.match(
           tag.name as string,
         );
+
+        core.info('Tag Version');
+        core.info(tagVersion as string);
+
         // Tag version can be a number according to the types,
         // but skimming through our artifact registry, it looks like it is always a string.
         return { name: tag.name as string, version: tagVersion as string };

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -57,14 +57,16 @@ export class ArtifactRegistryDockerRegistryClient {
   }
 
   /**
+   * getGitCommitsBetweenTags
    *
+   * @param {string} prevTag
+   *   The previous docker tag: of the following format: main---0013567-2024.04-g<githash>
+   * @param {string} nextTag
+   *  The next docker tag: main---0013567-2024.04-g<githash>
    *
+   * @param {object} dockerImageRepository
    *
-   *
-   *
-   *
-   *
-   *
+   * @returns {Promise} - The promise which resolves to an array of relevant commit strings.
    */
   async getGitCommitsBetweenTags({
     prevTag,
@@ -270,6 +272,10 @@ function getRelevantCommits(
   prevTag: string,
   nextTag: string,
   dockerTags: Tag[],
+  /**
+   * Should map from `projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/servicename/tags/2022.02-278-g123456789` -> `2022.02-278-g123456789`
+   * Should be a wrapper around the ArtifactRegistryClient, but written this way for testability, so the behavior can be injected.
+   */
   getTagFromDockerTagName: (dockerTagName: string) => string,
 ): string[] {
   // We want to get the minimum tag for each version, since this implies those commits
@@ -279,7 +285,6 @@ function getRelevantCommits(
     if (!dockerTag.version || !dockerTag.name) continue;
 
     const tag = getTagFromDockerTagName(dockerTag.name);
-    core.info(`Tag from DockerTag name ${tag}`);
 
     // We only care about the tags between prev and next that have a git commit
     const gitCommitMatches = tag.match(/-g([0-9a-fA-F]+)$/);

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -85,7 +85,7 @@ export class ArtifactRegistryDockerRegistryClient {
         }),
       })
     )[0];
-    core.info(`Docker Tags ${JSON.stringify(dockerTags)}`);
+    core.info(`Docker Tags ${JSON.stringify(dockerTags.slice(0, 5))}`);
 
     // We are going to get all of the relevant tags with unique hashes.
 
@@ -103,7 +103,7 @@ export class ArtifactRegistryDockerRegistryClient {
         return { name: tag.name as string, version: tagVersion as string };
       });
 
-    core.info(`Step1 Tags ${JSON.stringify(tags)}`);
+    core.info(`Step1 Tags ${JSON.stringify(tags.slice(0, 5))}`);
 
     const relevantCommits: string[] = getTagsInRange(
       prevTag,

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -132,12 +132,12 @@ export class ArtifactRegistryDockerRegistryClient {
       relevantCommits.push(tagBound);
     }
 
-    core.info(`Relevant Commits ${Array.from(relevantCommits).join(', ')}`);
-
     // Sort commits ascending
-    return relevantCommits
+    const result = relevantCommits
       .sort((a, b) => a.tag.localeCompare(b.tag))
       .map((c) => c.commit);
+    core.info(`Relevant Commits ${result.join(', ')}`);
+    return result;
   }
 
   async getAllEquivalentTags({

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -235,7 +235,7 @@ function isMainVersion(version: string): boolean {
  * pr-15028---0013576-2024.04-gabcdefge979bd9243574e44a63a73b0f4e12ede56
  * main---0013572-2024.04-gabcdefg4d7f58193abc9e24a476133a771ca979c2
  *
- * So nwe just split on `-` and get the last value, minus the `g` prefix
+ * So we just split on `-` and get the last value, minus the `g` prefix
  *
  * This will error if the tag version is not well-formed.
  */

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -115,7 +115,7 @@ export class ArtifactRegistryDockerRegistryClient {
           .tag as string;
       },
     );
-    core.info(`Relevant Commits ${revelantCommits.join(', ')}`);
+
     return revelantCommits;
   }
 

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -92,39 +92,52 @@ export class ArtifactRegistryDockerRegistryClient {
     )[0];
     core.info(`Docker Tags ${JSON.stringify(dockerTags.slice(0, 5))}`);
 
-    // We are going to get all of the relevant tags with unique hashes.
-
     // We want to get the minimum tag for each version, since this implies those commits
     // made a change to the docker image so are relevant to the diff.
-    // Tags are of the format `main---0013572-2024.04-acbdef1234558193abc9e24a476133a771ca979c2`
-    const tags = dockerTags
-      .filter((tag) => tag.version && tag.name)
-      .map((tag) => {
-        core.info('Tag in map');
-        core.info(JSON.stringify(tag));
-        const tagVersion = this.client.pathTemplates.tagPathTemplate.match(
-          tag.name as string,
-        ).tag;
+    const tagBoundsMap = new Map<string, { tag: string; commit: string }>();
+    for (const dockerTag of dockerTags) {
+      if (!dockerTag.version || !dockerTag.name) continue;
 
-        core.info('Tag Version');
-        core.info(tagVersion as string);
+      const tag = this.client.pathTemplates.tagPathTemplate.match(
+        dockerTag.name,
+      ).tag as string;
 
-        // Tag version can be a number according to the types,
-        // but skimming through our artifact registry, it looks like it is always a string.
-        return { name: tag.name as string, version: tagVersion as string };
-      });
+      // We only care about the tags between prev and next that have a git commit
+      const gitCommitMatches = tag.match(/-g([0-9a-fA-F]+)$/);
+      if (
+        ((tag >= prevTag && tag <= nextTag) ||
+          (tag <= prevTag && tag >= nextTag)) &&
+        gitCommitMatches
+      ) {
+        const minTag = tagBoundsMap.get(dockerTag.version);
+        if (minTag && minTag.tag > tag) {
+          minTag.tag = tag;
+          minTag.commit = gitCommitMatches[1];
+        } else {
+          tagBoundsMap.set(dockerTag.version, {
+            tag,
+            commit: gitCommitMatches[1],
+          });
+        }
+      }
+    }
 
-    core.info(`Step1 Tags ${JSON.stringify(tags.slice(0, 5))}`);
+    const relevantCommits = new Array<{ tag: string; commit: string }>();
 
-    const relevantCommits: string[] = getTagsInRange(
-      prevTag,
-      nextTag,
-      tags,
-    ).map(getTagCommitHash);
+    for (const tagBound of tagBoundsMap.values()) {
+      // We can skip the tag we are just coming from as a min
+      if (tagBound.tag === prevTag) {
+        continue;
+      }
+      relevantCommits.push(tagBound);
+    }
 
     core.info(`Relevant Commits ${Array.from(relevantCommits).join(', ')}`);
 
-    return relevantCommits;
+    // Sort commits ascending
+    return relevantCommits
+      .sort((a, b) => a.tag.localeCompare(b.tag))
+      .map((c) => c.commit);
   }
 
   async getAllEquivalentTags({

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -102,9 +102,9 @@ export class ArtifactRegistryDockerRegistryClient {
       .map((tag) => {
         core.info('Tag in map');
         core.info(JSON.stringify(tag));
-        const { tagVersion } = this.client.pathTemplates.tagPathTemplate.match(
+        const tagVersion = this.client.pathTemplates.tagPathTemplate.match(
           tag.name as string,
-        );
+        ).tag;
 
         core.info('Tag Version');
         core.info(tagVersion as string);

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -9,8 +9,19 @@ export interface GetAllEquivalentTagsOptions {
   tag: string;
 }
 
+export interface GitCommitsBetweenTagsOptions {
+  prevTag: string;
+  nextTag: string;
+  /** The name of the specific Docker image in question (ie, a Docker
+   * "repository", not an Artifact Registry "repository" that contains them.) */
+  dockerImageRepository: string;
+}
+
 export interface DockerRegistryClient {
   getAllEquivalentTags(options: GetAllEquivalentTagsOptions): Promise<string[]>;
+  getGitCommitsBetweenTags(
+    options: GitCommitsBetweenTagsOptions,
+  ): Promise<string[]>;
 }
 
 export class ArtifactRegistryDockerRegistryClient {
@@ -43,6 +54,97 @@ export class ArtifactRegistryDockerRegistryClient {
     }
 
     this.repositoryFields = { project, location, repository };
+  }
+
+  async getGitCommitsBetweenTags({
+    prevTag,
+    nextTag,
+    dockerImageRepository,
+  }: {
+    prevTag: string;
+    nextTag: string;
+    dockerImageRepository: string;
+  }): Promise<string[]> {
+    core.info(
+      `running diff docker tags ${prevTag} ${nextTag} ${dockerImageRepository}`,
+    );
+    // Input is relatively trusted; this is largely to prevent mistaken uses
+    // like specifying a full Docker-style repository with slashes.
+    if (dockerImageRepository.includes('/')) {
+      throw Error('repository cannot contain a slash');
+    }
+
+    // Note: we don't need `listTagsAsync` (which is recommended) because we
+    // only care about the first element in the result array, which is the list of tags.
+    // https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#auto-pagination
+    const dockerTags = (
+      await this.client.listTags({
+        parent: this.client.pathTemplates.packagePathTemplate.render({
+          ...this.repositoryFields,
+          package: dockerImageRepository,
+        }),
+      })
+    )[0];
+
+    // We are going to get all of the relevant tags with unique hashes.
+
+    // We want to get the minimum tag for each version, since this implies those commits
+    // made a change to the docker image so are relevant to the diff.
+    // Tags are of the format `main---0013572-2024.04-acbdef1234558193abc9e24a476133a771ca979c2`
+    const tagBoundsMap = new Map<string, { tag: string; commit: string }>();
+    for (const dockerTag of dockerTags) {
+      if (!dockerTag.version || !dockerTag.name) continue;
+
+      const { tag } = this.client.pathTemplates.tagPathTemplate.match(
+        dockerTag.name,
+      );
+
+      // If it is a number we can ignore the tag
+      if (typeof tag !== 'string') continue;
+
+      // We only care about the tags between prev and next that have a git commit
+      const gitCommitMatches = tag.match(/-g([0-9a-fA-F]+)$/);
+      if (!gitCommitMatches) continue;
+
+      // Only include tags newer than previous, and older than next.
+      // Note, this may need some rework later when we explicitly want to call out rollbacks
+      // and other shenanigans.
+      if (tag >= nextTag || tag <= prevTag) continue;
+
+      if (
+        ((tag >= prevTag && tag <= nextTag) ||
+          (tag <= prevTag && tag >= nextTag)) &&
+        gitCommitMatches
+      ) {
+        const minTag = tagBoundsMap.get(dockerTag.version);
+        if (minTag && minTag.tag > tag) {
+          minTag.tag = tag;
+          minTag.commit = gitCommitMatches[1];
+        } else {
+          tagBoundsMap.set(dockerTag.version, {
+            tag,
+            commit: gitCommitMatches[1],
+          });
+        }
+      }
+    }
+
+    const relevantCommits = new Array<{ tag: string; commit: string }>();
+
+    for (const tagBound of tagBoundsMap.values()) {
+      // We can skip the tag we are just coming from as a min
+      if (tagBound.tag === prevTag) {
+        continue;
+      }
+      relevantCommits.push(tagBound);
+    }
+
+    core.info(`Relevant Commits ${Array.from(relevantCommits).join(', ')}`);
+
+    // Sort commits ascending
+    return relevantCommits
+      .sort((a, b) => a.tag.localeCompare(b.tag))
+      .map((c) => c.commit);
   }
 
   async getAllEquivalentTags({
@@ -109,6 +211,13 @@ export class CachingDockerRegistryClient {
     },
   });
 
+  async getGitCommitsBetweenTags(
+    options: GitCommitsBetweenTagsOptions,
+  ): Promise<string[]> {
+    // For now we aren't caching anything since this will on run on promotion prs
+    return this.wrapped.getGitCommitsBetweenTags(options);
+  }
+
   async getAllEquivalentTags(
     options: GetAllEquivalentTagsOptions,
   ): Promise<string[]> {
@@ -123,4 +232,17 @@ export class CachingDockerRegistryClient {
     }
     return tags;
   }
+}
+
+export type Tag = {
+  name: string;
+  version: string;
+};
+
+export function getCommitsBetweenTags(
+  prevTag: Tag,
+  nextTag: Tag,
+  tags: Tag[],
+): string[] {
+  return [];
 }

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -206,7 +206,15 @@ export class CachingDockerRegistryClient {
   }
 }
 
-export type Tag = {
+/**
+ * An example format of a docker tag:
+ * {
+ *   "name":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/tags/2022.02-278-g123456789",
+ *   "version":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/versions/sha256:123abc456defg"
+ * }
+ *
+ */
+export type DockerTag = {
   name: string;
   version: string;
 };
@@ -214,8 +222,8 @@ export type Tag = {
 export function getTagsInRange(
   prevVersion: string,
   nextVersion: string,
-  tags: Tag[],
-): Tag[] {
+  tags: DockerTag[],
+): DockerTag[] {
   if (!(isMainVersion(prevVersion) && isMainVersion(nextVersion))) {
     return [];
   }
@@ -246,11 +254,11 @@ function isMainVersion(version: string): boolean {
  *
  * This will error if the tag version is not well-formed.
  */
-function getTagCommitHash(tag: Tag): string {
+function getTagCommitHash(tag: DockerTag): string {
   return (tag.version.split('-').at(-1) as string).substring(1);
 }
 
-function dedupNeighboringTags(tags: Tag[]): Tag[] {
+function dedupNeighboringTags(tags: DockerTag[]): DockerTag[] {
   if (tags.length === 0) {
     return [];
   }
@@ -276,7 +284,7 @@ function dedupNeighboringTags(tags: Tag[]): Tag[] {
  * @param {string} nextTag
  *  The next docker tag: main---0013567-2024.04-g<githash>
  *
- * @param {Tag[]} dockerTags
+ * @param {DockerTag[]} dockerTags
  *  The docker tags as we need to parse and filter into relevant commits. Provided by a previous call to the artifact registry.
  *
  *
@@ -289,7 +297,7 @@ function dedupNeighboringTags(tags: Tag[]): Tag[] {
 function getRelevantCommits(
   prevTag: string,
   nextTag: string,
-  dockerTags: Tag[],
+  dockerTags: DockerTag[],
   /**
    * Should map from `projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/servicename/tags/2022.02-278-g123456789` -> `2022.02-278-g123456789`
    * Should be a wrapper around the ArtifactRegistryClient, but written this way for testability, so the behavior can be injected.

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -186,7 +186,7 @@ export class CachingDockerRegistryClient {
   async getGitCommitsBetweenTags(
     options: GitCommitsBetweenTagsOptions,
   ): Promise<string[]> {
-    // For now we aren't caching anything since this will on run on promotion prs
+    // For now we aren't caching anything since this will only run on promotion prs
     return this.wrapped.getGitCommitsBetweenTags(options);
   }
 

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -102,7 +102,14 @@ export class ArtifactRegistryDockerRegistryClient {
         return { name: tag.name as string, version: tagVersion as string };
       });
 
-    return getTagsInRange(prevTag, nextTag, tags).map(getTagCommitHash);
+    const relevantCommits: string[] = getTagsInRange(
+      prevTag,
+      nextTag,
+      tags,
+    ).map(getTagCommitHash);
+    core.info(`Relevant Commits ${Array.from(relevantCommits).join(', ')}`);
+
+    return relevantCommits;
   }
 
   async getAllEquivalentTags({
@@ -214,11 +221,11 @@ export function getTagsInRange(
     })
     .filter((tag) => isMainVersion(tag.version));
 
-  const res = dedupNeighboringTags(tagsAfterInitialFilters);
+  const res = dtedupNeighboringTags(tagsAfterInitialFilters);
   return res;
 }
 
-function isMainVersion(version: string): boolean {
+function isMsainVersion(version: string): boolean {
   return version.startsWith('main---');
 }
 
@@ -228,7 +235,7 @@ function isMainVersion(version: string): boolean {
  * pr-15028---0013576-2024.04-gabcdefge979bd9243574e44a63a73b0f4e12ede56
  * main---0013572-2024.04-gabcdefg4d7f58193abc9e24a476133a771ca979c2
  *
- * So we just split on `-` and get the last value, minus the `g` prefix
+ * So nwe just split on `-` and get the last value, minus the `g` prefix
  *
  * This will error if the tag version is not well-formed.
  */

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -85,7 +85,7 @@ export class ArtifactRegistryDockerRegistryClient {
         }),
       })
     )[0];
-    core.info(`Docker Tags ${Array.from(dockerTags).join(', ')}`);
+    core.info(`Docker Tags ${JSON.stringify(dockerTags)}`);
 
     // We are going to get all of the relevant tags with unique hashes.
 
@@ -103,7 +103,7 @@ export class ArtifactRegistryDockerRegistryClient {
         return { name: tag.name as string, version: tagVersion as string };
       });
 
-    core.info(`Step1 Tags ${Array.from(tags).join(', ')}`);
+    core.info(`Step1 Tags ${JSON.stringify(tags)}`);
 
     const relevantCommits: string[] = getTagsInRange(
       prevTag,

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -306,7 +306,7 @@ export function getRelevantCommits(
   // We want to get the minimum tag for each version, since this implies those commits
   // made a change to the docker image so are relevant to the diff.
   // const tagBoundsMap = new Map<string, { tag: string; commit: string }>();
-  const validTags = new Array<{
+  const relevantCommitsWithTagInfo = new Array<{
     version: string;
     tag: string;
     commit: string;
@@ -346,7 +346,7 @@ export function getRelevantCommits(
         tag,
         commit: gitCommitMatches[1],
       };
-      validTags.push(currTagInfo);
+      relevantCommitsWithTagInfo.push(currTagInfo);
     }
   }
 
@@ -369,9 +369,10 @@ export function getRelevantCommits(
   // const result = relevantCommits
   //   .sort((a, b) => a.tag.localeCompare(b.tag))
   //   .map((c) => c.commit);
-  const result = dedupNeighboringTags(validTags)
+  const result = dedupNeighboringTags(relevantCommitsWithTagInfo)
     .sort((a, b) => a.tag.localeCompare(b.tag))
     .map((c) => c.commit);
+  core.info(`Relevant Commits ${result.join(', ')}`);
   return result;
 }
 

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -239,10 +239,11 @@ export type Tag = {
   version: string;
 };
 
-export function getCommitsBetweenTags(
-  prevTag: Tag,
-  nextTag: Tag,
-  tags: Tag[],
-): string[] {
-  return [];
+export function getTagsInRange(prevTag: Tag, nextTag: Tag, tags: Tag[]): Tag[] {
+  const sortedTags = [...tags].sort((a, b) => (a.version > b.version ? 1 : -1));
+  const res = sortedTags.filter((tag) => {
+    return tag.version > prevTag.version && tag.version < nextTag.version;
+  });
+  console.log(res);
+  return res;
 }

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -56,6 +56,16 @@ export class ArtifactRegistryDockerRegistryClient {
     this.repositoryFields = { project, location, repository };
   }
 
+  /**
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   */
   async getGitCommitsBetweenTags({
     prevTag,
     nextTag,
@@ -79,8 +89,8 @@ export class ArtifactRegistryDockerRegistryClient {
     // https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#auto-pagination
     // These tags look like the following:
     // {
-    //   "name":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/tags/2022.02-278-g16607e3143",
-    //   "version":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/versions/sha256:ef8b944a2c6fc5e20b3df6a1500292cf65e28039f3daa8a6df55b84c5eaaecca"
+    //   "name":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/tags/2022.02-278-g123456789",
+    //   "version":"projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/identity/versions/sha256:123abc456defg"
     // }
     const dockerTags = (
       await this.client.listTags({
@@ -90,7 +100,6 @@ export class ArtifactRegistryDockerRegistryClient {
         }),
       })
     )[0].filter((tag) => tag.version && tag.name);
-    core.info(`Docker Tags ${JSON.stringify(dockerTags.slice(0, 5))}`);
 
     const revelantCommits = getRelevantCommits(
       prevTag,
@@ -261,7 +270,7 @@ function getRelevantCommits(
   prevTag: string,
   nextTag: string,
   dockerTags: Tag[],
-  getTagFromTagDockerTagName: (dockerTagName: string) => string,
+  getTagFromDockerTagName: (dockerTagName: string) => string,
 ): string[] {
   // We want to get the minimum tag for each version, since this implies those commits
   // made a change to the docker image so are relevant to the diff.
@@ -269,7 +278,8 @@ function getRelevantCommits(
   for (const dockerTag of dockerTags) {
     if (!dockerTag.version || !dockerTag.name) continue;
 
-    const tag = getTagFromTagDockerTagName(dockerTag.name);
+    const tag = getTagFromDockerTagName(dockerTag.name);
+    core.info(`Tag from DockerTag name ${tag}`);
 
     // We only care about the tags between prev and next that have a git commit
     const gitCommitMatches = tag.match(/-g([0-9a-fA-F]+)$/);

--- a/src/github.ts
+++ b/src/github.ts
@@ -65,7 +65,8 @@ export class OctokitGitHubClient {
     headCommitSHA,
   }: CompareCommitsOptions): Promise<CompareCommitsResult | null> {
     const { owner, repo } = parseRepoURL(repoURL);
-    const basehead = `${baseCommitSHA}...${headCommitSHA}`;
+    // Include '^' to be inclusive of the head commit.
+    const basehead = `${baseCommitSHA}...${headCommitSHA}^`;
     this.logAPICall('repos.compareCommits', `${owner}/${repo} ${basehead}`);
     const result = (
       await this.octokit.rest.repos.compareCommitsWithBasehead({

--- a/src/github.ts
+++ b/src/github.ts
@@ -13,9 +13,22 @@ export interface GetTreeSHAForPathOptions {
   path: string;
 }
 
+export interface CompareCommitsOptions {
+  repoURL: string;
+  baseCommitSHA: string;
+  headCommitSHA: string;
+}
+
+export interface CompareCommitsResult {
+  commits: { commitSHA: string; message: string }[];
+}
+
 export interface GitHubClient {
   resolveRefToSHA(options: ResolveRefToSHAOptions): Promise<string>;
   getTreeSHAForPath(options: GetTreeSHAForPathOptions): Promise<string | null>;
+  compareCommits(
+    options: CompareCommitsOptions,
+  ): Promise<CompareCommitsResult | null>;
 }
 
 interface OwnerAndRepo {
@@ -40,6 +53,33 @@ interface AllTreesForCommit {
 export class OctokitGitHubClient {
   apiCalls = new Map<string, number>();
   constructor(private octokit: ReturnType<typeof getOctokit>) {}
+
+  async compareCommits({
+    repoURL,
+    baseCommitSHA,
+    headCommitSHA,
+  }: CompareCommitsOptions): Promise<CompareCommitsResult | null> {
+    // const allTreesForCommit = await this.allTreesForCommitCache.fetch(
+    //   JSON.stringify({ repoURL, commitSHA }),
+    //   { context: { repoURL, commitSHA } },
+    // );
+    // if (!allTreesForCommit) {
+    //   // This shouldn't happen: errors should lead to an error being thrown from
+    //   // the previous line, but the fetchMethod always returns an actual item.
+    //   throw Error(`Unexpected missing entry in allTreesForCommitCache`);
+    // }
+    // const shaFromCache = allTreesForCommit.pathToTreeSHA.get(path);
+    // if (shaFromCache) {
+    //   return shaFromCache;
+    // }
+    // if (!allTreesForCommit.truncated) {
+    //   // The recursive listing we got from GitHub is complete, so if it doesn't
+    //   // have the tree in question, then the path just doesn't exist (as a tree)
+    //   // at the given commit.
+    //   return null;
+    //
+    return null;
+  }
 
   private logAPICall(name: string, description: string): void {
     core.info(`[GH API] ${name} ${description}`);

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,7 +20,12 @@ export interface CompareCommitsOptions {
 }
 
 export interface CompareCommitsResult {
-  commits: { commitSHA: string; message: string; author: string | null }[];
+  commits: {
+    commitSHA: string;
+    message: string;
+    author: string | null;
+    commitUrl: string;
+  }[];
 }
 
 export interface GitHubClient {
@@ -74,6 +79,7 @@ export class OctokitGitHubClient {
         commitSHA: commit.sha,
         message: commit.commit.message,
         author: commit.author?.name ?? commit.commit.author?.email ?? null,
+        commitUrl: commit.html_url,
       })),
     };
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,7 +20,7 @@ export interface CompareCommitsOptions {
 }
 
 export interface CompareCommitsResult {
-  commits: { commitSHA: string; message: string }[];
+  commits: { commitSHA: string; message: string; author: string | null }[];
 }
 
 export interface GitHubClient {
@@ -73,6 +73,7 @@ export class OctokitGitHubClient {
       commits: result.map((commit) => ({
         commitSHA: commit.sha,
         message: commit.commit.message,
+        author: commit.author?.name ?? commit.commit.author?.email ?? null,
       })),
     };
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -302,6 +302,12 @@ export class CachingGitHubClient {
     return cached.boxed;
   }
 
+  async compareCommits(
+    options: CompareCommitsOptions,
+  ): Promise<CompareCommitsResult | null> {
+    return this.wrapped.compareCommits(options);
+  }
+
   dump(): CachingGitHubClientDump {
     // We don't dump resolveRefToSHACache because it is not immutable (it tracks
     // the current commits on main, etc).

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,11 +173,12 @@ async function processFile(
 
   if (core.getBooleanInput('update-promoted-values')) {
     const promotionTargetRegexp = core.getInput('promotion-target-regexp');
-    contents = await updatePromotedValues(
+    [contents] = await updatePromotedValues(
       contents,
       promotionTargetRegexp || null,
       logger,
       dockerRegistryClient,
+      gitHubClient,
     );
 
     // Assumption: The filepath is of the format `teams/{team-name}` or `teams/{team-name}/migrations` (for db migrations)

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ async function processFile(
       contents,
       promotionTargetRegexp || null,
       logger,
+      dockerRegistryClient,
     );
 
     // Assumption: The filepath is of the format `teams/{team-name}` or `teams/{team-name}/migrations` (for db migrations)

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from './github';
 import { updateDockerTags } from './update-docker-tags';
 import { updateGitRefs } from './update-git-refs';
-import { updatePromotedValues } from './update-promoted-values';
+import { RelevantCommit, updatePromotedValues } from './update-promoted-values';
 import { PrefixingLogger } from './log';
 import { inspect } from 'util';
 
@@ -173,7 +173,8 @@ async function processFile(
 
   if (core.getBooleanInput('update-promoted-values')) {
     const promotionTargetRegexp = core.getInput('promotion-target-regexp');
-    [contents] = await updatePromotedValues(
+    let relevantCommits: Map<string, RelevantCommit[]>;
+    [contents, relevantCommits] = await updatePromotedValues(
       contents,
       promotionTargetRegexp || null,
       logger,
@@ -191,6 +192,7 @@ async function processFile(
     core.setOutput('team', team);
     core.setOutput('is-migration', isMigration);
     core.setOutput('target-env', env);
+    core.setOutput('relevant-commits', JSON.stringify(relevantCommits));
   }
 
   await writeFile(filename, contents);

--- a/src/update-docker-tags.ts
+++ b/src/update-docker-tags.ts
@@ -158,6 +158,12 @@ async function checkTagsAgainstArtifactRegistryAndModifyScalars(
       );
     }
 
+    await dockerRegistryClient.getGitCommitsBetweenTags({
+      prevTag: trackable.tag,
+      nextTag: earliestMatchingTag,
+      dockerImageRepository: trackable.dockerImageRepository,
+    });
+
     // It's OK if the current one is null because that's what we're overwriting, but we shouldn't
     // overwrite *to* something that doesn't exist.
     logger.info(

--- a/src/update-docker-tags.ts
+++ b/src/update-docker-tags.ts
@@ -158,12 +158,6 @@ async function checkTagsAgainstArtifactRegistryAndModifyScalars(
       );
     }
 
-    const commits = await dockerRegistryClient.getGitCommitsBetweenTags({
-      prevTag: trackable.tag,
-      nextTag: earliestMatchingTag,
-      dockerImageRepository: trackable.dockerImageRepository,
-    });
-
     // It's OK if the current one is null because that's what we're overwriting, but we shouldn't
     // overwrite *to* something that doesn't exist.
     logger.info(

--- a/src/update-docker-tags.ts
+++ b/src/update-docker-tags.ts
@@ -158,7 +158,7 @@ async function checkTagsAgainstArtifactRegistryAndModifyScalars(
       );
     }
 
-    await dockerRegistryClient.getGitCommitsBetweenTags({
+    const commits = await dockerRegistryClient.getGitCommitsBetweenTags({
       prevTag: trackable.tag,
       nextTag: earliestMatchingTag,
       dockerImageRepository: trackable.dockerImageRepository,

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -246,6 +246,9 @@ async function findPromotes(
                 })) ||
               [];
             console.info(`relevantCommits: ${JSON.stringify(relevantCommits)}`);
+            console.info(
+              `number of commits: ${commits.length} ${githubCommits?.commits.length} ${relevantCommits.length}`,
+            );
           }
         }
       }

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -37,6 +37,7 @@ export async function updatePromotedValues(
   // We decide what to do and then we do it, just in case there are any
   // overlaps between our reads and writes.
   logger.info('Looking for promote');
+  logger.info('test log');
   const promotes = findPromotes(document, promotionTargetRE2);
 
   logger.info(`Promotes: ${JSON.stringify(promotes)}`);

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -38,7 +38,7 @@ export async function updatePromotedValues(
   _logger: PrefixingLogger,
   dockerRegistryClient: DockerRegistryClient | null = null,
   gitHubClient: GitHubClient | null = null,
-): Promise<[string, RelevantCommit[]]> {
+): Promise<[string, Map<string, RelevantCommit[]>]> {
   const logger = _logger.withExtendedPrefix('[promote] ');
 
   // We use re2-wasm instead of built-in RegExp so we don't have to worry about
@@ -52,7 +52,7 @@ export async function updatePromotedValues(
   // If the file is empty (or just whitespace or whatever), that's fine; we
   // can just leave it alone.
   if (!document) {
-    return [contents, []];
+    return [contents, new Map()];
   }
 
   // We decide what to do and then we do it, just in case there are any
@@ -72,7 +72,12 @@ export async function updatePromotedValues(
   for (const { scalarTokenWriter, value } of promotes) {
     scalarTokenWriter.write(value);
   }
-  return [stringify(), []];
+
+  const relevantCommits: Map<string, RelevantCommit[]> = new Map();
+  for (const [serviceName, commits] of promotes.map((p) => p.relevantCommits)) {
+    relevantCommits.set(serviceName, commits);
+  }
+  return [stringify(), relevantCommits];
 }
 
 async function findPromotes(

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -39,6 +39,8 @@ export async function updatePromotedValues(
   logger.info('Looking for promote');
   const promotes = findPromotes(document, promotionTargetRE2);
 
+  logger.info(`Promotes: ${JSON.stringify(promotes)}`);
+
   logger.info('Copying values');
   for (const { scalarTokenWriter, value } of promotes) {
     scalarTokenWriter.write(value);

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -56,6 +56,18 @@ function findPromotes(
     if (promotionTargetRE2 && !promotionTargetRE2.test(myName)) {
       continue;
     }
+    //
+    // Expected format of a block:
+    //
+    // my-service-prod:
+    //   track: <branch (main) | pr (pr-1234)>
+    //   gitConfig:
+    //     ref: <commit>
+    //   dockerImage:
+    //     tag: main---0013586-2024.04-<commit>
+    //   promote:
+    //     from: my-service-staging
+    //
     if (!me.has('promote')) {
       continue;
     }
@@ -116,6 +128,9 @@ function findPromotes(
 
     for (const collectionPath of yamlPaths) {
       const sourceValue = fromBlock.getIn(collectionPath);
+      console.log(`sourceValue: ${JSON.stringify(sourceValue)}`);
+      console.log(`from: ${JSON.stringify(from)}`);
+      console.log(`collectionPath: ${JSON.stringify(collectionPath)}`);
       if (typeof sourceValue !== 'string') {
         throw Error(`Could not promote from ${[from, ...collectionPath]}`);
       }

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -241,6 +241,8 @@ async function getRelevantCommits(
     'repoURL',
   ]) as string | undefined;
 
+  console.info(`repoURL: ${JSON.stringify(repoURL)}`);
+
   if (typeof repoURL !== 'string') return [];
 
   const dockerImageRepository: string | undefined = block.getIn([
@@ -248,6 +250,10 @@ async function getRelevantCommits(
     'dockerImage',
     'repository',
   ]) as string | undefined;
+
+  console.info(
+    `dockerImageRepository: ${JSON.stringify(dockerImageRepository)}`,
+  );
 
   if (typeof dockerImageRepository !== 'string') return [];
 

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -142,6 +142,8 @@ function findPromotes(
       if (!yaml.isScalar(targetNode)) {
         throw Error(`Could not promote to ${[myName, ...collectionPath]}`);
       }
+      console.log(`targetNode: ${JSON.stringify(targetNode)}`);
+      console.log(`myName: ${JSON.stringify(myName)}`);
       const scalarToken = targetNode.srcToken;
       if (!yaml.CST.isScalar(scalarToken)) {
         // this probably can't happen, but let's make the types happy

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -24,7 +24,14 @@ export interface RelevantCommit {
    * The commit message
    */
   message: string;
+  /**
+   * The author of the commit, if available. Should be name, or email, or null.
+   */
   author: string | null;
+  /**
+   * A link to view the commit on Github.
+   */
+  commitUrl: string;
 }
 
 const DEFAULT_YAML_PATHS = [

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -12,18 +12,19 @@ interface Promote {
    * Relevant commit hashes to this promotion, keyed by the service block name
    * Sorted from oldest to newest.
    */
-  relevantCommits: Map<string, RelevantCommit[]>;
+  relevantCommits: [string, RelevantCommit[]];
 }
 
 interface RelevantCommit {
   /**
    * The commit hash
    */
-  commit: string;
+  commitSHA: string;
   /**
    * The commit message
    */
   message: string;
+  author: string | null;
 }
 
 const DEFAULT_YAML_PATHS = [
@@ -194,6 +195,7 @@ async function findPromotes(
       //
 
       let commits: string[] = [];
+      let relevantCommits: RelevantCommit[] = [];
       if (gitHubClient && dockerRegistryClient) {
         let dockerImageRepository: string | undefined;
         let repoURL: string | undefined;
@@ -239,7 +241,7 @@ async function findPromotes(
               headCommitSHA: last,
             });
             console.info(`githubCommits: ${JSON.stringify(githubCommits)}`);
-            const relevantCommits =
+            relevantCommits =
               (githubCommits &&
                 githubCommits.commits.filter((commit) => {
                   return commits.includes(commit.commitSHA);
@@ -255,14 +257,10 @@ async function findPromotes(
 
       console.info(`commits: ${JSON.stringify(commits)}`);
 
-      // fetch range of commits from github
-      // filter out anything not in commits
-      // const commitRange = gitHubClient.getCommitRange({
-
       promotes.push({
         scalarTokenWriter: new ScalarTokenWriter(scalarToken, document.schema),
         value: sourceValue,
-        relevantCommits: commits ? new Map([[myName, []]]) : new Map(),
+        relevantCommits: [myName, relevantCommits],
       });
     }
   }

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -9,10 +9,10 @@ interface Promote {
   scalarTokenWriter: ScalarTokenWriter;
   value: string;
   /**
-   * Relevant commit hashes to this promotion
+   * Relevant commit hashes to this promotion, keyed by the service block name
    * Sorted from oldest to newest.
    */
-  relevantCommits: string[];
+  relevantCommits: Map<string, RelevantCommit[]>;
 }
 
 interface RelevantCommit {
@@ -229,7 +229,7 @@ async function findPromotes(
       promotes.push({
         scalarTokenWriter: new ScalarTokenWriter(scalarToken, document.schema),
         value: sourceValue,
-        relevantCommits: commits ?? [],
+        relevantCommits: commits ? new Map([[myName, commits]]) : new Map(),
       });
     }
   }

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -239,9 +239,12 @@ async function findPromotes(
               headCommitSHA: last,
             });
             console.info(`githubCommits: ${JSON.stringify(githubCommits)}`);
-            const relevantCommits = githubCommits && githubCommits.commits.filter((commit) => {
-              return commits.includes(commit.commitSHA);
-            }) || [];
+            const relevantCommits =
+              (githubCommits &&
+                githubCommits.commits.filter((commit) => {
+                  return commits.includes(commit.commitSHA);
+                })) ||
+              [];
             console.info(`relevantCommits: ${JSON.stringify(relevantCommits)}`);
           }
         }

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -174,7 +174,7 @@ async function findPromotes(
       //
 
       let dockerImageRepository: string | undefined;
-      const globalBlock = promote.get('global');
+      const globalBlock = document.get('global');
       console.info(`globalBlock: ${JSON.stringify(globalBlock)}`);
       if (globalBlock && yaml.isMap(globalBlock)) {
         const dockerImageBlock = globalBlock.get('dockerImage');
@@ -189,9 +189,6 @@ async function findPromotes(
       }
       console.info(
         `dockerImageRepository: ${JSON.stringify(dockerImageRepository)}`,
-      );
-      console.info(
-        `dockerRegistryClient: ${JSON.stringify(dockerRegistryClient)}`,
       );
       let commits;
       if (

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -65,7 +65,6 @@ export async function updatePromotedValues(
   // We decide what to do and then we do it, just in case there are any
   // overlaps between our reads and writes.
   logger.info('Looking for promote');
-  logger.info('test log');
   const promotes = await findPromotes(
     document,
     promotionTargetRE2,

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -175,15 +175,24 @@ async function findPromotes(
 
       let dockerImageRepository: string | undefined;
       const globalBlock = promote.get('global');
+      console.info(`globalBlock: ${JSON.stringify(globalBlock)}`);
       if (globalBlock && yaml.isMap(globalBlock)) {
         const dockerImageBlock = globalBlock.get('dockerImage');
+        console.info(`dockerImageBlock: ${JSON.stringify(dockerImageBlock)}`);
         if (dockerImageBlock && yaml.isMap(dockerImageBlock)) {
           const repository = dockerImageBlock.get('repository');
+          console.info(`repository: ${JSON.stringify(repository)}`);
           if (repository && typeof repository === 'string') {
             dockerImageRepository = repository;
           }
         }
       }
+      console.info(
+        `dockerImageRepository: ${JSON.stringify(dockerImageRepository)}`,
+      );
+      console.info(
+        `dockerRegistryClient: ${JSON.stringify(dockerRegistryClient)}`,
+      );
       let commits;
       if (
         dockerRegistryClient &&

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -197,8 +197,8 @@ async function findPromotes(
         typeof targetNode.value === 'string'
       ) {
         commits = await dockerRegistryClient.getGitCommitsBetweenTags({
-          prevTag: sourceValue,
-          nextTag: targetNode.value,
+          prevTag: targetNode.value,
+          nextTag: sourceValue,
           dockerImageRepository,
         });
       }

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -15,7 +15,7 @@ interface Promote {
   relevantCommits: [string, RelevantCommit[]];
 }
 
-interface RelevantCommit {
+export interface RelevantCommit {
   /**
    * The commit hash
    */


### PR DESCRIPTION
1) Get all the tags from image registry
2) Filter tags based on prev and start input
3) Filter tags to make sure they are of the right format (`main---`). Currently having a git commit hash at the end is assumed based on skimming through our images.
4) Of the remaining tags, filter out duplicates that are next to each other in the timeline (to setup rollback notes later, by allowing `1 2 3 1`, but filtering `1 1 1 2 2 2` to `1 2`)

Later:
- Do a single github look up for the commit range and match messages with the commits above
- Write this to the PR body on create (and update)
- Think harder about caching