### PR TITLE
Handle non-sha values in compare lookup

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -64,8 +64,8 @@ export class OctokitGitHubClient {
     baseCommitSHA,
     headCommitSHA,
   }: CompareCommitsOptions): Promise<CompareCommitsResult | null> {
-    const baseIsCommitSHA = baseCommitSHA.match(/([0-9a-fA-F]+)$/);
-    const headIsCommitSHA = headCommitSHA.match(/([0-9a-fA-F]+)$/);
+    const baseIsCommitSHA = baseCommitSHA.match(/\b([a-f0-9]{40})\b/);
+    const headIsCommitSHA = headCommitSHA.match(/\b([a-f0-9]{40})\b/);
     if (!baseIsCommitSHA || !headIsCommitSHA) return null;
 
     const { owner, repo } = parseRepoURL(repoURL);

--- a/src/github.ts
+++ b/src/github.ts
@@ -66,7 +66,9 @@ export class OctokitGitHubClient {
   }: CompareCommitsOptions): Promise<CompareCommitsResult | null> {
     const baseIsCommitSHA = baseCommitSHA.match(/\b([a-f0-9]{40})\b/);
     const headIsCommitSHA = headCommitSHA.match(/\b([a-f0-9]{40})\b/);
-    if (!baseIsCommitSHA || !headIsCommitSHA) return null;
+    console.log(JSON.stringify(baseIsCommitSHA));
+    console.log(JSON.stringify(headIsCommitSHA));
+    if (baseIsCommitSHA === null || headIsCommitSHA === null) return null;
 
     const { owner, repo } = parseRepoURL(repoURL);
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -64,16 +64,6 @@ export class OctokitGitHubClient {
     baseCommitSHA,
     headCommitSHA,
   }: CompareCommitsOptions): Promise<CompareCommitsResult | null> {
-    const baseIsCommitSHA = baseCommitSHA.match(/\b([a-f0-9]{40})\b/);
-    const headIsCommitSHA = headCommitSHA.match(/\b([a-f0-9]{40})\b/);
-    console.log(JSON.stringify(baseIsCommitSHA));
-    console.log(JSON.stringify(headIsCommitSHA));
-    this.logAPICall(
-      'repos.compareCommits',
-      `${JSON.stringify(baseIsCommitSHA)}/${JSON.stringify(headIsCommitSHA)}`,
-    );
-    if (baseIsCommitSHA === null || headIsCommitSHA === null) return null;
-
     const { owner, repo } = parseRepoURL(repoURL);
 
     // Include '^' to be inclusive of the head commit.
@@ -168,8 +158,8 @@ export class OctokitGitHubClient {
     }
     const { owner, repo } = parseRepoURL(repoURL);
     const prNumber = ref.match(/^pr-([0-9]+)$/)?.[1];
-    const refParameter = prNumber ? `pull / ${prNumber} / head` : ref;
-    this.logAPICall('repos.getCommit', `${owner} / ${repo} ${refParameter}`);
+    const refParameter = prNumber ? `pull/${prNumber}/head` : ref;
+    this.logAPICall('repos.getCommit', `${owner}/${repo} ${refParameter}`);
     const sha = (
       await this.octokit.rest.repos.getCommit({
         owner,

--- a/src/github.ts
+++ b/src/github.ts
@@ -68,6 +68,10 @@ export class OctokitGitHubClient {
     const headIsCommitSHA = headCommitSHA.match(/\b([a-f0-9]{40})\b/);
     console.log(JSON.stringify(baseIsCommitSHA));
     console.log(JSON.stringify(headIsCommitSHA));
+    this.logAPICall(
+      'repos.compareCommits',
+      `${JSON.stringify(baseIsCommitSHA)}/${JSON.stringify(headIsCommitSHA)}`,
+    );
     if (baseIsCommitSHA === null || headIsCommitSHA === null) return null;
 
     const { owner, repo } = parseRepoURL(repoURL);

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -83,6 +83,9 @@ export async function updatePromotedValues(
   for (const [serviceName, commits] of promotes.map((p) => p.relevantCommits)) {
     relevantCommits.set(serviceName, commits);
   }
+
+  logger.info(`Relevant commits: ${JSON.stringify(relevantCommits)}`);
+
   return [stringify(), relevantCommits];
 }
 


### PR DESCRIPTION
Follow up from https://github.com/apollographql/argocd-config-updater/pull/53

Looks like the code formatter added some spacing that broke looking up commits by `pull/<pr id>/head`