### PR TITLE
Use Object.fromEntries to make Map JSON.stringify-able

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,10 @@ async function processFile(
     core.setOutput('team', team);
     core.setOutput('is-migration', isMigration);
     core.setOutput('target-env', env);
-    core.setOutput('relevant-commits', JSON.stringify(relevantCommits));
+    core.setOutput(
+      'relevant-commits',
+      JSON.stringify(Object.fromEntries(relevantCommits)),
+    );
   }
 
   await writeFile(filename, contents);

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -84,7 +84,9 @@ export async function updatePromotedValues(
     relevantCommits.set(serviceName, commits);
   }
 
-  logger.info(`Relevant commits: ${JSON.stringify(relevantCommits)}`);
+  logger.info(
+    `Relevant commits: ${JSON.stringify(Object.fromEntries(relevantCommits))}`,
+  );
 
   return [stringify(), relevantCommits];
 }


### PR DESCRIPTION
using `JSON.stringify` on a `Map` always results in `{}`. By running it through `Object.fromEntries` we get a real object that can be converted to json.