### PR TITLE
Filter out empty lists of commits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,7 @@ async function processFile(
       logger,
       dockerRegistryClient,
       gitHubClient,
+      shortFilename,
     );
 
     // Assumption: The filepath is of the format `teams/{team-name}` or `teams/{team-name}/migrations` (for db migrations)

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,13 +174,18 @@ async function processFile(
   if (core.getBooleanInput('update-promoted-values')) {
     const promotionTargetRegexp = core.getInput('promotion-target-regexp');
     let relevantCommits: Map<string, RelevantCommit[]>;
+
+    // Assumption: The filepath is of the format `teams/{team-name}/service` or `teams/{team-name}/migrations` (for db migrations)
+    const serviceName =
+      core.getInput('files').split('/')[2]?.toLowerCase() ?? 'unknown';
+
     [contents, relevantCommits] = await updatePromotedValues(
       contents,
       promotionTargetRegexp || null,
       logger,
       dockerRegistryClient,
       gitHubClient,
-      shortFilename,
+      serviceName,
     );
 
     // Assumption: The filepath is of the format `teams/{team-name}` or `teams/{team-name}/migrations` (for db migrations)

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -45,6 +45,7 @@ export async function updatePromotedValues(
   _logger: PrefixingLogger,
   dockerRegistryClient: DockerRegistryClient | null = null,
   gitHubClient: GitHubClient | null = null,
+  shortFilename = 'unknown',
 ): Promise<[string, Map<string, RelevantCommit[]>]> {
   const logger = _logger.withExtendedPrefix('[promote] ');
 
@@ -82,7 +83,7 @@ export async function updatePromotedValues(
   const relevantCommits: Map<string, RelevantCommit[]> = new Map();
   for (const [serviceName, commits] of promotes.map((p) => p.relevantCommits)) {
     if (commits.length === 0) continue;
-    relevantCommits.set(serviceName, commits);
+    relevantCommits.set(`${shortFilename}/${serviceName}`, commits);
   }
 
   logger.info(

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -45,7 +45,7 @@ export async function updatePromotedValues(
   _logger: PrefixingLogger,
   dockerRegistryClient: DockerRegistryClient | null = null,
   gitHubClient: GitHubClient | null = null,
-  shortFilename = 'unknown',
+  serviceName = 'unknown',
 ): Promise<[string, Map<string, RelevantCommit[]>]> {
   const logger = _logger.withExtendedPrefix('[promote] ');
 
@@ -81,9 +81,9 @@ export async function updatePromotedValues(
   }
 
   const relevantCommits: Map<string, RelevantCommit[]> = new Map();
-  for (const [serviceName, commits] of promotes.map((p) => p.relevantCommits)) {
+  for (const [blockName, commits] of promotes.map((p) => p.relevantCommits)) {
     if (commits.length === 0) continue;
-    relevantCommits.set(`${shortFilename}/${serviceName}`, commits);
+    relevantCommits.set(`${serviceName}/${blockName}`, commits);
   }
 
   logger.info(

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -81,6 +81,7 @@ export async function updatePromotedValues(
 
   const relevantCommits: Map<string, RelevantCommit[]> = new Map();
   for (const [serviceName, commits] of promotes.map((p) => p.relevantCommits)) {
+    if (commits.length === 0) continue;
     relevantCommits.set(serviceName, commits);
   }
 


### PR DESCRIPTION
Filter out empty lists of commits from being included in the results map. Also, parse the service name from the file input and include that in the relevant commits map key.