### PR TITLE
Remove some recently-added outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,18 +39,6 @@ outputs:
   suggested-promotion-branch-name:
     description: 'A combination of the promotion-target-regexp and files inputs with special characters changed to underscores; appropriate for constructing a branch name'
 
-  target-env:
-    description: 'The target promotion environment'
-
-  team:
-    description: 'The team responsible for the candidate promotion'
-
-  is-migration:
-    description: 'If the promotion is for running DB migrations'
-
-  relevant-commits:
-    description: 'A map of relevant commits for service names as JSON'
-
 runs:
   using: node20
   main: dist/index.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from './github';
 import { updateDockerTags } from './update-docker-tags';
 import { updateGitRefs } from './update-git-refs';
-import { RelevantCommit, updatePromotedValues } from './update-promoted-values';
+import { updatePromotedValues } from './update-promoted-values';
 import { PrefixingLogger } from './log';
 import { inspect } from 'util';
 
@@ -173,28 +173,12 @@ async function processFile(
 
   if (core.getBooleanInput('update-promoted-values')) {
     const promotionTargetRegexp = core.getInput('promotion-target-regexp');
-    let relevantCommits: Map<string, RelevantCommit[]>;
-    [contents, relevantCommits] = await updatePromotedValues(
+    [contents] = await updatePromotedValues(
       contents,
       promotionTargetRegexp || null,
       logger,
       dockerRegistryClient,
       gitHubClient,
-    );
-
-    // Assumption: The filepath is of the format `teams/{team-name}` or `teams/{team-name}/migrations` (for db migrations)
-    const team =
-      core.getInput('files').split('/')[1]?.toLowerCase() ?? 'unknown';
-    const isMigration = core.getInput('files').includes('migrations');
-    // Assumption: Environment name is the provided target regexp
-    const env = core.getInput('promotion-target-regexp');
-
-    core.setOutput('team', team);
-    core.setOutput('is-migration', isMigration);
-    core.setOutput('target-env', env);
-    core.setOutput(
-      'relevant-commits',
-      JSON.stringify(Object.fromEntries(relevantCommits)),
     );
   }
 


### PR DESCRIPTION
The relevant-commits output is part of an unfinished feature and we can
re-add it as we finish the feature; it also shouldn't be set repeatedly
on each file but only once at the top with merged contents.

The other outputs were a bit hardcoded for our particular repository and
we've found a way to get that information directly in our workflow
rather than through this action. (Additionally, these outputs should
have been set at the top level rather than in processFile as they are
the same for each file.)