### PR TITLE
Update docker tag fetching logic

### DIFF
--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -192,25 +192,53 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should return an empty list if left bound is not for `main---`', async () => {
-    const [prev, prevDockerTag] = makePRTag(5, '2024', 4);
-    const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
+    const prev = `pr-123---0000005-2024.04-g${commitSha()}`;
+    const next = `main---0000010-2024.04-g${commitSha()}`;
+    const prevDockerTag: DockerTag = {
+      tag: prev,
+      version: 'a',
+    };
+    const nextDockerTag: DockerTag = {
+      tag: next,
+      version: 'e',
+    };
     const tags = [
       prevDockerTag,
       nextDockerTag,
-      stubDockerTag(7, '2024', 4),
-      stubDockerTag(6, '2024', 4),
+      {
+        tag: `main---0000007-2024.04-g${commitSha()}`,
+        version: 'b',
+      },
+      {
+        tag: `main---0000006-2024.04-g${commitSha()}`,
+        version: 'c',
+      },
     ];
     expect(getRelevantCommits(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should return an empty list if right bound is not for `main---`', async () => {
-    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
-    const [next, nextDockerTag] = makePRTag(10, '2024', 4);
+    const prev = `main---0000005-2024.04-g${commitSha()}`;
+    const next = `pr-123---0000010-2024.04-g${commitSha()}`;
+    const prevDockerTag: DockerTag = {
+      tag: prev,
+      version: 'a',
+    };
+    const nextDockerTag: DockerTag = {
+      tag: next,
+      version: 'e',
+    };
     const tags = [
       prevDockerTag,
       nextDockerTag,
-      stubDockerTag(7, '2024', 4),
-      stubDockerTag(6, '2024', 4),
+      {
+        tag: `main---0000007-2024.04-g${commitSha()}`,
+        version: 'b',
+      },
+      {
+        tag: `main---0000006-2024.04-g${commitSha()}`,
+        version: 'c',
+      },
     ];
     expect(getRelevantCommits(prev, next, tags)).toStrictEqual([]);
   });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -12,14 +12,7 @@ import { DockerTag, getRelevantCommits } from '../src/artifactRegistry';
 function stubDockerTag(count: number, year: string, month: number): DockerTag {
   const shortHash = faker.git.commitSha();
   const hash = faker.git.commitSha();
-  return makeDockerTag(
-    EXAMPLE_TAG_NAME_PATH,
-    count,
-    year,
-    month,
-    hash,
-    shortHash,
-  );
+  return makeDockerTag(count, year, month, hash, shortHash);
 }
 
 function makePRTag(
@@ -33,14 +26,7 @@ function makePRTag(
   const hash = faker.git.commitSha();
 
   const prTag = `pr-123---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
-  const dockerTag = makeDockerTag(
-    EXAMPLE_TAG_NAME_PATH,
-    count,
-    year,
-    month,
-    hash,
-    shortHash,
-  );
+  const dockerTag = makeDockerTag(count, year, month, hash, shortHash);
   return [prTag, dockerTag];
 }
 
@@ -55,14 +41,7 @@ function makeMainTag(
   const hash = faker.git.commitSha();
 
   const mainTag = `main---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
-  const dockerTag = makeDockerTag(
-    EXAMPLE_TAG_NAME_PATH,
-    count,
-    year,
-    month,
-    hash,
-    shortHash,
-  );
+  const dockerTag = makeDockerTag(count, year, month, hash, shortHash);
   return [mainTag, dockerTag];
 }
 
@@ -78,8 +57,11 @@ function getAllHashes(tags: DockerTag[]): string[] {
   return tags.map(getHash);
 }
 
+function commitSha(): string {
+  return faker.git.commitSha();
+}
+
 function makeDockerTag(
-  namePathPrefix: string,
   count: number,
   year: string,
   month: number,
@@ -90,51 +72,66 @@ function makeDockerTag(
   const paddedMonth = month.toString().padStart(2, '0');
 
   return {
-    name: `${namePathPrefix}/tags/${paddedCount}-${year}.${paddedMonth}-g${shortHash}`,
-    version: `${namePathPrefix}/versions/sha256:${hash}`,
+    tag: `main---${paddedCount}-${year}.${paddedMonth}-g${shortHash}`,
+    version: `some/path/versions/sha256:${hash}`,
   };
 }
 
 /**
  * transforming the tag into the `main---count-year.month-ggitCommitHash` format
  */
-function getTagFromDockerTagName(dockerTag: DockerTag): string {
-  const gitCommitMatches = dockerTag.version.match(/sha256:([0-9a-fA-F]+)$/);
-  if (!gitCommitMatches) {
-    throw new Error(`Could not find git commit in ${dockerTag.version}`);
-  }
-  const nameTagData = dockerTag.name.split('/').pop() as string;
-  const withoutHash = nameTagData.split('-').slice(0, 2).join('-');
-  return `main---${withoutHash}-g${gitCommitMatches[1]}`;
-}
-
-const EXAMPLE_TAG_NAME_PATH =
-  'projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/example';
+// function getTagFromDockerTagName(dockerTag: DockerTag): string {
+//   const gitCommitMatches = dockerTag.version.match(/sha256:([0-9a-fA-F]+)$/);
+//   if (!gitCommitMatches) {
+//     throw new Error(`Could not find git commit in ${dockerTag.version}`);
+//   }
+//   const nameTagData = dockerTag.tag.split('/').pop() as string;
+//   const withoutHash = nameTagData.split('-').slice(0, 2).join('-');
+//   return `main---${withoutHash}-g${gitCommitMatches[1]}`;
+// }
 
 describe('ArtifactRegistry.getRelevantCommits', () => {
   it('should return nothing when given an empty list', async () => {
-    const [prev] = makeMainTag(1, '2024', 4);
-    const [next] = makeMainTag(2, '2024', 4);
-    expect(
-      getRelevantCommits(prev, next, [], getTagFromDockerTagName),
-    ).toStrictEqual([]);
+    const [prev] = `main---0013572-2024.04-g${commitSha()}`;
+    const [next] = `main---0013573-2024.04-g${commitSha()}`;
+    expect(getRelevantCommits(prev, next, [])).toStrictEqual([]);
   });
 
   it('should filter commits before prev (inclusive)', async () => {
-    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
-    const [next] = makeMainTag(10, '2024', 4);
+    const prev = `main---0000005-2024.04-g${commitSha()}`;
+    const next = `main---0000010-2024.04-g${commitSha()}`;
+    const prevDockerTag: DockerTag = {
+      tag: prev,
+      version: 'a',
+    };
+    const afterDockerTagCommit = commitSha();
+    const afterDockerTag: DockerTag = {
+      tag: `main---0000006-2024.04-g${afterDockerTagCommit}`,
+      version: 'e',
+    };
+
     const tags = [
       prevDockerTag,
-      stubDockerTag(4, '2024', 4),
-      stubDockerTag(3, '2024', 4),
-      stubDockerTag(0, '2024', 4),
+      {
+        tag: `main---0000004-2024.04-g${commitSha()}`,
+        version: 'b',
+      },
+      {
+        tag: `main---0000003-2024.04-g${commitSha()}`,
+        version: 'c',
+      },
+      {
+        tag: `main---0000000-2024.04-g${commitSha()}`,
+        version: 'd',
+      },
+      afterDockerTag,
     ];
-    expect(
-      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual([]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual([
+      afterDockerTagCommit,
+    ]);
   });
 
-  it('should filter commits after next (inclusive)', async () => {
+  it('should filter commits after next (exclusive)', async () => {
     const [prev] = makeMainTag(5, '2024', 4);
     const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
     const tags = [
@@ -143,12 +140,10 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       stubDockerTag(12, '2024', 4),
       stubDockerTag(100, '2024', 4),
     ];
-    expect(
-      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual([]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual([nextDockerTag]);
   });
 
-  it('should include commits between prev and next (in sorted order)', async () => {
+  it('should include commits between prev and next (in sorted order) -- next is inclusive', async () => {
     const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
     const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
     const tags = [
@@ -158,10 +153,8 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       stubDockerTag(6, '2024', 4),
     ];
 
-    const expected = getAllHashes([tags[3], tags[2]]);
-    expect(
-      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual(expected);
+    const expected = getAllHashes([tags[3], tags[2], nextDockerTag]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual(expected);
   });
 
   it('should return an empty list if left bound is not for `main---`', async () => {
@@ -173,9 +166,7 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       stubDockerTag(7, '2024', 4),
       stubDockerTag(6, '2024', 4),
     ];
-    expect(
-      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual([]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should return an empty list if right bound is not for `main---`', async () => {
@@ -187,9 +178,7 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
       stubDockerTag(7, '2024', 4),
       stubDockerTag(6, '2024', 4),
     ];
-    expect(
-      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual([]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual([]);
   });
 
   it('should dedup consecutive commit hashes', async () => {
@@ -199,47 +188,12 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
     const hash2 = faker.git.commitSha();
     const shortHash1 = faker.git.commitSha({ length: 7 });
     const shortHash2 = faker.git.commitSha({ length: 7 });
-    const commit1First = makeDockerTag(
-      EXAMPLE_TAG_NAME_PATH,
-      6,
-      '2024',
-      4,
-      hash1,
-      shortHash1,
-    );
-    const commit1Second = makeDockerTag(
-      EXAMPLE_TAG_NAME_PATH,
-      7,
-      '2024',
-      4,
-      hash1,
-      shortHash1,
-    );
+    const commit1First = makeDockerTag(6, '2024', 4, hash1, shortHash1);
+    const commit1Second = makeDockerTag(7, '2024', 4, hash1, shortHash1);
     const otherCommit = stubDockerTag(8, '2024', 4);
-    const commit2First = makeDockerTag(
-      EXAMPLE_TAG_NAME_PATH,
-      9,
-      '2024',
-      4,
-      hash2,
-      shortHash2,
-    );
-    const commit2Second = makeDockerTag(
-      'main',
-      10,
-      '2024',
-      4,
-      hash2,
-      shortHash2,
-    );
-    const commit1Third = makeDockerTag(
-      EXAMPLE_TAG_NAME_PATH,
-      11,
-      '2024',
-      4,
-      hash1,
-      shortHash1,
-    );
+    const commit2First = makeDockerTag(9, '2024', 4, hash2, shortHash2);
+    const commit2Second = makeDockerTag(10, '2024', 4, hash2, shortHash2);
+    const commit1Third = makeDockerTag(11, '2024', 4, hash1, shortHash1);
 
     const tags = [
       prevDockerTag,
@@ -255,9 +209,13 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
     // We expect consecutive duplicate commit hashes to be deduped
     // However if it returns later, this could imply a revert or rollback.
     // At the moment, we just keep that in, but later we should explicitly flag as a rollback.
-    const expected = getAllHashes([tags[2], tags[4], tags[5], tags[7]]);
-    expect(
-      getRelevantCommits(prev, next, tags, getTagFromDockerTagName),
-    ).toStrictEqual(expected);
+    const expected = getAllHashes([
+      tags[2],
+      tags[4],
+      tags[5],
+      tags[7],
+      tags[1],
+    ]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual(expected);
   });
 });

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -243,19 +243,47 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
     expect(getRelevantCommits(prev, next, tags)).toStrictEqual([]);
   });
 
-  it('should dedup consecutive commit hashes', async () => {
-    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
-    const [next, nextDockerTag] = makeMainTag(20, '2024', 4);
-    const hash1 = faker.git.commitSha();
-    const hash2 = faker.git.commitSha();
-    const shortHash1 = faker.git.commitSha({ length: 7 });
-    const shortHash2 = faker.git.commitSha({ length: 7 });
-    const commit1First = makeDockerTag(6, '2024', 4, hash1, shortHash1);
-    const commit1Second = makeDockerTag(7, '2024', 4, hash1, shortHash1);
-    const otherCommit = stubDockerTag(8, '2024', 4);
-    const commit2First = makeDockerTag(9, '2024', 4, hash2, shortHash2);
-    const commit2Second = makeDockerTag(10, '2024', 4, hash2, shortHash2);
-    const commit1Third = makeDockerTag(11, '2024', 4, hash1, shortHash1);
+  it('should dedup consecutive versions', async () => {
+    const prev = `main---0000005-2024.04-g${commitSha()}`;
+    const next = `main---0000020-2024.04-g${commitSha()}`;
+    const prevDockerTag: DockerTag = {
+      tag: prev,
+      version: 'a',
+    };
+    const nextDockerTag: DockerTag = {
+      tag: next,
+      version: 'e',
+    };
+
+    const commit1First = {
+      tag: `main---0000006-2024.04-g${commitSha()}`,
+      version: 'b',
+    };
+
+    const commit1Second = {
+      tag: `main---0000007-2024.04-g${commitSha()}`,
+      version: 'b',
+    };
+
+    const otherCommit = {
+      tag: `main---0000008-2024.04-g${commitSha()}`,
+      version: 'c',
+    };
+
+    const commit2First = {
+      tag: `main---0000009-2024.04-g${commitSha()}`,
+      version: 'd',
+    };
+
+    const commit2Second = {
+      tag: `main---0000010-2024.04-g${commitSha()}`,
+      version: 'd',
+    };
+
+    const commit1Third = {
+      tag: `main---0000011-2024.04-g${commitSha()}`,
+      version: 'b',
+    };
 
     const tags = [
       prevDockerTag,

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -46,9 +46,9 @@ function makeMainTag(
 }
 
 function getHash(dockerTag: DockerTag): string {
-  const gitCommitMatches = dockerTag.version.match(/sha256:([0-9a-fA-F]+)$/);
+  const gitCommitMatches = dockerTag.tag.match(/-g([0-9a-fA-F]+)$/);
   if (!gitCommitMatches) {
-    throw new Error(`Could not find git commit in ${dockerTag.version}`);
+    throw new Error(`Could not find git commit in ${dockerTag.tag}`);
   }
   return gitCommitMatches[1];
 }
@@ -163,13 +163,28 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should include commits between prev and next (in sorted order) -- next is inclusive', async () => {
-    const [prev, prevDockerTag] = makeMainTag(5, '2024', 4);
-    const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
+    const prev = `main---0000005-2024.04-g${commitSha()}`;
+    const nextCommitSHA = commitSha();
+    const next = `main---0000010-2024.04-g${nextCommitSHA}`;
+    const prevDockerTag: DockerTag = {
+      tag: prev,
+      version: 'a',
+    };
+    const nextDockerTag: DockerTag = {
+      tag: next,
+      version: 'e',
+    };
     const tags = [
       prevDockerTag,
       nextDockerTag,
-      stubDockerTag(7, '2024', 4),
-      stubDockerTag(6, '2024', 4),
+      {
+        tag: `main---0000007-2024.04-g${commitSha()}`,
+        version: 'b',
+      },
+      {
+        tag: `main---0000006-2024.04-g${commitSha()}`,
+        version: 'c',
+      },
     ];
 
     const expected = getAllHashes([tags[3], tags[2], nextDockerTag]);

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -9,42 +9,6 @@ import { DockerTag, getRelevantCommits } from '../src/artifactRegistry';
  *
  */
 
-function stubDockerTag(count: number, year: string, month: number): DockerTag {
-  const shortHash = faker.git.commitSha();
-  const hash = faker.git.commitSha();
-  return makeDockerTag(count, year, month, hash, shortHash);
-}
-
-function makePRTag(
-  count: number,
-  year: string,
-  month: number,
-): [string, DockerTag] {
-  const paddedCount = count.toString().padStart(7, '0');
-  const paddedMonth = month.toString().padStart(2, '0');
-  const shortHash = faker.git.commitSha({ length: 7 });
-  const hash = faker.git.commitSha();
-
-  const prTag = `pr-123---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
-  const dockerTag = makeDockerTag(count, year, month, hash, shortHash);
-  return [prTag, dockerTag];
-}
-
-function makeMainTag(
-  count: number,
-  year: string,
-  month: number,
-): [string, DockerTag] {
-  const paddedCount = count.toString().padStart(7, '0');
-  const paddedMonth = month.toString().padStart(2, '0');
-  const shortHash = faker.git.commitSha({ length: 7 });
-  const hash = faker.git.commitSha();
-
-  const mainTag = `main---${paddedCount}-${year}.${paddedMonth}-g${hash}`;
-  const dockerTag = makeDockerTag(count, year, month, hash, shortHash);
-  return [mainTag, dockerTag];
-}
-
 function getHash(dockerTag: DockerTag): string {
   const gitCommitMatches = dockerTag.tag.match(/-g([0-9a-fA-F]+)$/);
   if (!gitCommitMatches) {
@@ -60,35 +24,6 @@ function getAllHashes(tags: DockerTag[]): string[] {
 function commitSha(): string {
   return faker.git.commitSha();
 }
-
-function makeDockerTag(
-  count: number,
-  year: string,
-  month: number,
-  hash: string,
-  shortHash: string,
-): DockerTag {
-  const paddedCount = count.toString().padStart(7, '0');
-  const paddedMonth = month.toString().padStart(2, '0');
-
-  return {
-    tag: `main---${paddedCount}-${year}.${paddedMonth}-g${shortHash}`,
-    version: `some/path/versions/sha256:${hash}`,
-  };
-}
-
-/**
- * transforming the tag into the `main---count-year.month-ggitCommitHash` format
- */
-// function getTagFromDockerTagName(dockerTag: DockerTag): string {
-//   const gitCommitMatches = dockerTag.version.match(/sha256:([0-9a-fA-F]+)$/);
-//   if (!gitCommitMatches) {
-//     throw new Error(`Could not find git commit in ${dockerTag.version}`);
-//   }
-//   const nameTagData = dockerTag.tag.split('/').pop() as string;
-//   const withoutHash = nameTagData.split('-').slice(0, 2).join('-');
-//   return `main---${withoutHash}-g${gitCommitMatches[1]}`;
-// }
 
 describe('ArtifactRegistry.getRelevantCommits', () => {
   it('should return nothing when given an empty list', async () => {

--- a/__tests__/artifact-registry.test.ts
+++ b/__tests__/artifact-registry.test.ts
@@ -132,15 +132,34 @@ describe('ArtifactRegistry.getRelevantCommits', () => {
   });
 
   it('should filter commits after next (exclusive)', async () => {
-    const [prev] = makeMainTag(5, '2024', 4);
-    const [next, nextDockerTag] = makeMainTag(10, '2024', 4);
+    const prev = `main---0000005-2024.04-g${commitSha()}`;
+    const nextCommitSHA = commitSha();
+    const next = `main---0000010-2024.04-g${nextCommitSHA}`;
+    const prevDockerTag: DockerTag = {
+      tag: prev,
+      version: 'a',
+    };
+    const nextDockerTag: DockerTag = {
+      tag: next,
+      version: 'e',
+    };
     const tags = [
+      prevDockerTag,
       nextDockerTag,
-      stubDockerTag(11, '2024', 4),
-      stubDockerTag(12, '2024', 4),
-      stubDockerTag(100, '2024', 4),
+      {
+        tag: `main---0000011-2024.04-g${commitSha()}`,
+        version: 'b',
+      },
+      {
+        tag: `main---0000012-2024.04-g${commitSha()}`,
+        version: 'c',
+      },
+      {
+        tag: `main---0000100-2024.04-g${commitSha()}`,
+        version: 'd',
+      },
     ];
-    expect(getRelevantCommits(prev, next, tags)).toStrictEqual([nextDockerTag]);
+    expect(getRelevantCommits(prev, next, tags)).toStrictEqual([nextCommitSHA]);
   });
 
   it('should include commits between prev and next (in sorted order) -- next is inclusive', async () => {

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -240,16 +240,12 @@ export type DockerTag = {
  *
  * @param {string} prevTag
  *   The previous docker tag: of the following format: main---0013567-2024.04-g<githash>
+ *
  * @param {string} nextTag
  *  The next docker tag: main---0013567-2024.04-g<githash>
  *
  * @param {DockerTag[]} dockerTags
  *  The docker tags as we need to parse and filter into relevant commits. Provided by a previous call to the artifact registry.
- *
- *
- * @param {function} getTagFromDockerTag
- *   Should map from `projects/platform-cross-environment/locations/us-central1/repositories/platform-docker/packages/servicename/tags/2022.02-278-g123456789` -> `2022.02-278-g123456789`
- *   Should be a wrapper around the ArtifactRegistryClient, but written this way for testability, so the behavior can be injected.
  *
  * @returns {string[]} - The relevant commits as strings
  */
@@ -258,12 +254,9 @@ export function getRelevantCommits(
   nextTag: string,
   dockerTags: DockerTag[],
 ): string[] {
-  console.log(`prevTag: ${prevTag}`);
-  console.log(`nextTag: ${nextTag}`);
   if (!isMainTag(prevTag)) return [];
   if (!isMainTag(nextTag)) return [];
 
-  console.log('Hello');
   /**
    * Going to loop over our docker tags, filtering out ones outside the relevant range, and build an array of tag info.
    *
@@ -276,20 +269,10 @@ export function getRelevantCommits(
   }>();
 
   for (const dockerTag of dockerTags) {
-    // TODO: Check this with a test
-    // if (!dockerTag.version || !dockerTag.name) continue;
     const tag = dockerTag.tag;
 
-    if (!isMainTag(tag)) {
-      console.log(`filtering because tag is not main ${tag}`);
-      continue;
-    }
-    if (!tagInRange(prevTag, nextTag, tag)) {
-      console.log(`filtering because tag is not in range ${tag}`);
-      continue;
-    }
-
-    console.log('Hello');
+    if (!isMainTag(tag)) continue;
+    if (!tagInRange(prevTag, nextTag, tag)) continue;
 
     // We only care about the tags between prev and next that have a git commit
     const gitCommitMatches = tag.match(/-g([0-9a-fA-F]+)$/);

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -243,8 +243,8 @@ export function getRelevantCommits(
   dockerTags: DockerTag[],
   getTagFromDockerTag: (dockerTag: DockerTag) => string,
 ): string[] {
-  if (!prevTag.startsWith('main')) return [];
-  if (!nextTag.startsWith('main')) return [];
+  if (!isMainTag(prevTag)) return [];
+  if (!isMainTag(nextTag)) return [];
 
   /**
    * Going to loop over our docker tags, filtering out ones outside the relevant range, and build an array of tag info.
@@ -262,7 +262,7 @@ export function getRelevantCommits(
 
     const tag = getTagFromDockerTag(dockerTag);
 
-    if (!tag.startsWith('main')) continue;
+    if (!isMainTag(tag)) continue;
     if (!tagInRange(prevTag, nextTag, tag)) continue;
 
     // We only care about the tags between prev and next that have a git commit
@@ -304,4 +304,8 @@ function dedupNeighboringTags(
     }
   }
   return res;
+}
+
+function isMainTag(tag: string): boolean {
+  return tag.startsWith('main---');
 }

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -103,7 +103,7 @@ export class ArtifactRegistryDockerRegistryClient {
       })
     )[0].filter((tag) => tag.version && tag.name);
 
-    const revelantCommits = getRelevantCommits(
+    const relevantCommits = getRelevantCommits(
       prevTag,
       nextTag,
       dockerTags.map((tag) => ({
@@ -116,7 +116,7 @@ export class ArtifactRegistryDockerRegistryClient {
       },
     );
 
-    return revelantCommits;
+    return relevantCommits;
   }
 
   async getAllEquivalentTags({


### PR DESCRIPTION
Follow up on feedback from https://github.com/apollographql/argocd-config-updater/pull/53

Refactoring and updating how we handle fetching docker tags and parsing out relevant commits.

Simplifying our model and making sure we filter duplicates based on the version instead of the commit hash.