### PR TITLE
Generate promoted commits Markdown

### DIFF
--- a/__tests__/update-promoted-values.test.ts
+++ b/__tests__/update-promoted-values.test.ts
@@ -15,22 +15,30 @@ const logger = PrefixingLogger.silent();
 describe('action', () => {
   it('updates git refs', async () => {
     const contents = await fixture('sample.yaml');
-    const [newContents] = await updatePromotedValues(contents, 'prod', logger);
+    const { newContents } = await updatePromotedValues(
+      contents,
+      'prod',
+      logger,
+    );
     expect(newContents).toMatchSnapshot();
 
     // It should be idempotent in this case.
-    const [actual] = await updatePromotedValues(newContents, 'prod', logger);
+    const { newContents: actual } = await updatePromotedValues(
+      newContents,
+      'prod',
+      logger,
+    );
     expect(actual).toBe(newContents);
   });
 
   it('respects defaults and explicit specifications for yamlPaths', async () => {
-    const [actual] = await updatePromotedValues(
+    const { newContents } = await updatePromotedValues(
       await fixture('yaml-paths-defaults.yaml'),
       null,
       logger,
     );
 
-    expect(actual).toMatchSnapshot();
+    expect(newContents).toMatchSnapshot();
   });
 
   it('throws if no default yamlPaths entry works', async () => {

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,15 @@ inputs:
     description: 'Update tracked gitConfig.ref fields'
     default: 'false'
 
+  update-docker-tags:
+    description: 'Update tracked dockerImage.tag fields'
+    default: 'false'
+
+  artifact-registry-repository:
+    description: 'If update-docker-tags or generate-promoted-commits-markdown is set, must be set to a string of the form `projects/PROJECT/locations/LOCATION/repositories/REPOSITORY`'
+
   update-docker-tags-for-artifact-registry-repository:
-    description: 'Updated tracked dockerImage.tag fields; must be set to a string of the form `projects/PROJECT/locations/LOCATION/repositories/REPOSITORY`'
+    description: 'DEPRECATED: equivalent to setting artifact-registry-repository and update-docker-tags'
 
   update-promoted-values:
     description: 'Process promote instructions'
@@ -31,13 +38,17 @@ inputs:
   parallelism:
     description: 'How many files to process in parallel'
     default: '1'
+  
+  generate-promoted-commits-markdown:
+    description: 'Generates the promoted-commits-markdown output'
+    default: 'false'
 
 outputs:
-  sanitized-promotion-target-regexp:
-    description: 'DEPRECATED: The promotion-target-regexp input with special characters changed to underscores; appropriate for constructing a branch name'
-
   suggested-promotion-branch-name:
     description: 'A combination of the promotion-target-regexp and files inputs with special characters changed to underscores; appropriate for constructing a branch name'
+  
+  promoted-commits-markdown:
+    description: 'Markdown describing the commits being promoted, if update-promoted-values and generate-promoted-commits-markdown are set.'
 
 runs:
   using: node20

--- a/src/github.ts
+++ b/src/github.ts
@@ -257,7 +257,7 @@ export class OctokitGitHubClient {
 export class CachingGitHubClient {
   constructor(
     private wrapped: GitHubClient,
-    dump?: CachingGitHubClientDump,
+    dump?: CachingGitHubClientDump | null,
   ) {
     if (dump) {
       this.getTreeSHAForPathCache.load(dump.treeSHAs);


### PR DESCRIPTION
Uses the foundation built by @tapegram to generate suggested PR description text with promoted commits.

This only analyzes changes to `dockerImage.tag`, not `gitConfig.ref` or anything else. It only works if the old and new tag both start with `main---` (the assumption being that this is reasonably reliable because `main` typically does not get force pushed).

- New `generate-promoted-commits-markdown` input and `promoted-commits-markdown`. Note that we now will not do the slow AR calls unless `generate-promoted-commits-markdown` is set; we plan to leave this off of our "dry run" for performance.
- Feed the commits found up the stack and eventually format as Markdown.
- Add the relevant git commit lookup from AR to the in-memory cache (after all, multiple files might have the same promotion, like two deployments of the same code with different config) and the disk cache. This bumps the API cache format to 2.
- Properly handle repoURL and dockerImage being set at the non-global level.
- Explicitly handle cases like "no version change" and "tags don't start with `main---`" with various nulls.
- Split `update-docker-tags-for-artifact-registry-repository` input into boolean `update-docker-tags` and string `artifact-registry-repository` so that you can specify the latter for generating markdown.

artifactRegistry.ts part mostly paired with @tapegram.