### PR TITLE
Include Helm chart changes in commit PR description

### DIFF
--- a/__tests__/caching.test.ts
+++ b/__tests__/caching.test.ts
@@ -10,7 +10,7 @@ describe('CachingDockerRegistryClient caches', () => {
         return [(++call).toString()];
       },
       async getGitCommitsBetweenTags() {
-        return [];
+        return { type: 'no-commits' };
       },
     });
 
@@ -44,8 +44,8 @@ describe('CachingGitHubClient caches', () => {
       async getTreeSHAForPath() {
         return '';
       },
-      async compareCommits() {
-        return null;
+      async getCommitSHAsForPath() {
+        return [];
       },
     });
 
@@ -78,8 +78,8 @@ describe('CachingGitHubClient caches', () => {
       async getTreeSHAForPath() {
         return (++call).toString();
       },
-      async compareCommits() {
-        return null;
+      async getCommitSHAsForPath() {
+        return [];
       },
     });
 

--- a/__tests__/update-docker-tags.test.ts
+++ b/__tests__/update-docker-tags.test.ts
@@ -1,6 +1,9 @@
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { GetAllEquivalentTagsOptions } from '../src/artifactRegistry';
+import {
+  DockerRegistryClient,
+  GetAllEquivalentTagsOptions,
+} from '../src/artifactRegistry';
 import { updateDockerTags } from '../src/update-docker-tags';
 import { PrefixingLogger } from '../src/log';
 
@@ -14,7 +17,7 @@ async function fixture(filename: string): Promise<string> {
 describe('action', () => {
   it('updates docker tags', async () => {
     const contents = await fixture('sample.yaml');
-    const dockerRegistryClient = {
+    const dockerRegistryClient: DockerRegistryClient = {
       async getAllEquivalentTags({ tag }: GetAllEquivalentTagsOptions) {
         return (
           {
@@ -40,7 +43,7 @@ describe('action', () => {
         );
       },
       async getGitCommitsBetweenTags() {
-        return [];
+        return { type: 'no-commits' };
       },
     };
     const logger = PrefixingLogger.silent();

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -14,8 +14,8 @@ const mockGitHubClient: GitHubClient = {
   async getTreeSHAForPath() {
     return `${Math.random()}`;
   },
-  async compareCommits() {
-    return null;
+  async getCommitSHAsForPath() {
+    return [];
   },
 };
 
@@ -56,8 +56,8 @@ describe('action', () => {
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'old' ? 'aaaa' : treeSHAForNew;
       },
-      async compareCommits() {
-        return null;
+      async getCommitSHAsForPath() {
+        return [];
       },
     };
 
@@ -86,8 +86,8 @@ describe('action', () => {
       async getTreeSHAForPath() {
         return 'aaaa';
       },
-      async compareCommits() {
-        return null;
+      async getCommitSHAsForPath() {
+        return [];
       },
     };
 
@@ -106,8 +106,8 @@ describe('action', () => {
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'd97b3a3240' ? 'bad' : 'aaaa';
       },
-      async compareCommits() {
-        return null;
+      async getCommitSHAsForPath() {
+        return [];
       },
     };
 
@@ -129,8 +129,8 @@ describe('action', () => {
       async getTreeSHAForPath({ commitSHA }) {
         return commitSHA === 'old' ? 'oldaaaa' : 'aaaa';
       },
-      async compareCommits() {
-        return null;
+      async getCommitSHAsForPath() {
+        return [];
       },
     };
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
 
   github-token:
-    description: 'GitHub token to read refs and trees; only needed if update-git-refs is set'
+    description: 'GitHub token to read refs and trees; only needed if update-git-refs or generate-promoted-commits-markdown is set'
 
   update-git-refs:
     description: 'Update tracked gitConfig.ref fields'

--- a/src/promotionInfo.ts
+++ b/src/promotionInfo.ts
@@ -1,0 +1,50 @@
+export interface PromotionInfoCommits {
+  type: 'commits';
+  commitSHAs: string[]; // non-empty
+}
+
+export function promotionInfoCommits(
+  commitSHAs: string[],
+): PromotionInfoCommits {
+  return { type: 'commits', commitSHAs };
+}
+
+/** Used when the value is being changed but there are no commits between the two
+ *  values (ie, no-op change). */
+export interface PromotionInfoNoCommits {
+  type: 'no-commits';
+}
+
+/** Used when the tag/ref value isn't changed at all. */
+export interface PromotionInfoNoChange {
+  type: 'no-change';
+}
+
+// If we're unable to tell what happened with a promotion, the message will
+// explain that.
+export interface PromotionInfoUnknown {
+  type: 'unknown';
+  message: string;
+}
+
+export function promotionInfoUnknown(message: string): PromotionInfoUnknown {
+  return { type: 'unknown', message };
+}
+
+export type PromotionInfo =
+  | PromotionInfoCommits
+  | PromotionInfoNoCommits
+  | PromotionInfoNoChange
+  | PromotionInfoUnknown;
+
+export interface EnvironmentPromotions {
+  trimmedRepoURL: string;
+  gitConfigPromotionInfo: PromotionInfo;
+  dockerImage: {
+    repository: string;
+    promotionInfo: PromotionInfo;
+  } | null; // null if there's no Docker image being tracked
+}
+
+// Map from environment (eg `staging`) to EnvironmentPromotions.
+export type PromotionsByTargetEnvironment = Map<string, EnvironmentPromotions>;


### PR DESCRIPTION
In #60 we looked at Docker tag changes, and based on the git commits mentioned in the tags and an analysis of all tags in the Artifact Registry repository, we figured out what commits affected the Docker tag and included information about it in the PR description.

Now we're doing the same thing for changes to the "ref" (Helm chart changes).

The basic algorithm is simple: ask GitHub for the list of commits affecting the Chart's path at the old and new ref; find the most recent "old" commit in the "new" list, and keep anything newer.

I did a fair amount of refactoring to create data structures that are explicit about the reasons that we might be changing a line in the file without actually knowing the list of commits.

This also removes an older unused attempt at implementing something similar (`compareCommits`).

Since this changes the format of the "git commits between tags" part of the API cache, I renamed the relevant field so it gets loaded properly (old caches will just be ignored)