### PR TITLE
Allow promotes to include named links

### DIFF
--- a/__tests__/__fixtures__/templates/templates.yaml
+++ b/__tests__/__fixtures__/templates/templates.yaml
@@ -1,0 +1,8 @@
+link-one:
+  text:
+    - literal: 'Link to '
+    - variable: foo
+  url:
+    - literal: 'https://some-site.example/logs/query?foo='
+    - variable: 'foo'
+    - literal: '&bar=yay'

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'path';
+import { readLinkTemplateMapFile, renderLinkTemplate } from '../src/templates';
+
+function fixtureFilename(filename: string): string {
+  return join(__dirname, '__fixtures__', 'templates', filename);
+}
+
+describe('templates', () => {
+  it('renders a template', async () => {
+    const templateMap = await readLinkTemplateMapFile(
+      fixtureFilename('templates.yaml'),
+    );
+    expect(
+      renderLinkTemplate(
+        templateMap,
+        'link-one',
+        new Map([
+          ['foo', 'hooray'],
+          ['bla', 'another'],
+        ]),
+      ),
+    ).toStrictEqual({
+      text: 'Link to hooray',
+      url: 'https://some-site.example/logs/query?foo=hooray&bar=yay',
+    });
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
   generate-promoted-commits-markdown:
     description: 'Generates the promoted-commits-markdown output'
     default: 'false'
+  
+  link-template-file:
+    description: 'If provided, a path to a YAML file mapping from template names to link templates. A template is a `text` and an `url`, each of which is a list of objects, each of which is of the form `{literal: "literal text"}` or `{variable: "variable-name"}.'
 
 outputs:
   suggested-promotion-branch-name:

--- a/src/promotionInfo.ts
+++ b/src/promotionInfo.ts
@@ -1,3 +1,5 @@
+import { Link } from './templates';
+
 export interface PromotionInfoCommits {
   type: 'commits';
   commitSHAs: string[]; // non-empty
@@ -44,6 +46,7 @@ export interface EnvironmentPromotions {
     repository: string;
     promotionInfo: PromotionInfo;
   } | null; // null if there's no Docker image being tracked
+  links: Link[];
 }
 
 // Map from environment (eg `staging`) to EnvironmentPromotions.

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,114 @@
+import * as yaml from 'yaml';
+import { readFile } from 'fs/promises';
+
+export interface TemplateLiteral {
+  literal: string;
+}
+
+export interface TemplateVariable {
+  variable: string;
+}
+
+export type TemplatePart = TemplateLiteral | TemplateVariable;
+
+export interface LinkTemplate {
+  text: TemplatePart[];
+  url: TemplatePart[];
+}
+
+export interface Link {
+  text: string;
+  url: string;
+}
+
+export type LinkTemplateMap = Map<string, LinkTemplate>;
+
+function renderTemplate(
+  template: TemplatePart[],
+  variables: Map<string, string>,
+): string {
+  return template
+    .map((part: TemplatePart) => {
+      if ('literal' in part) {
+        return part.literal;
+      }
+      const variableValue = variables.get(part.variable);
+      if (variableValue === undefined) {
+        throw Error(`Unknown template variable ${part.variable}`);
+      }
+      return variableValue;
+    })
+    .join('');
+}
+
+export function renderLinkTemplate(
+  templateMap: LinkTemplateMap,
+  name: string,
+  variables: Map<string, string>,
+): Link {
+  const template = templateMap.get(name);
+  if (!template) {
+    throw Error(`Unknown template ${name}`);
+  }
+  return {
+    text: renderTemplate(template.text, variables),
+    url: renderTemplate(template.url, variables),
+  };
+}
+
+export async function readLinkTemplateMapFile(
+  filename: string,
+): Promise<LinkTemplateMap> {
+  const contents = await readFile(filename, 'utf-8');
+  const templateMap = new Map<string, LinkTemplate>();
+  const parsed = yaml.parse(contents) as unknown;
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw Error(`Template map file ${filename} must be a map at the top level`);
+  }
+  for (const [name, parsedLinkTemplateAny] of Object.entries(parsed)) {
+    const parsedLinkTemplate = parsedLinkTemplateAny as unknown;
+    if (typeof parsedLinkTemplate !== 'object' || parsedLinkTemplate === null) {
+      throw Error(`Template ${name} in ${filename} must be a map`);
+    }
+    if (!('text' in parsedLinkTemplate && 'url' in parsedLinkTemplate)) {
+      throw Error(
+        `Template ${name} in ${filename} must contain 'text' and 'url' keys`,
+      );
+    }
+    templateMap.set(name, {
+      text: ensureTemplate(
+        parsedLinkTemplate.text,
+        `Template ${name}.text in ${filename}`,
+      ),
+      url: ensureTemplate(
+        parsedLinkTemplate.url,
+        `Template ${name}.url in ${filename}`,
+      ),
+    });
+  }
+  return templateMap;
+}
+
+function ensureTemplate(
+  parsedTemplate: unknown,
+  errorPrefix: string,
+): TemplatePart[] {
+  if (!Array.isArray(parsedTemplate)) {
+    throw Error(`${errorPrefix} must be a list`);
+  }
+  const template: TemplatePart[] = [];
+  for (const partAny of parsedTemplate) {
+    const part = partAny as unknown;
+    if (typeof part !== 'object' || part === null) {
+      throw Error(`${errorPrefix} contains a non-map part`);
+    }
+    if ('literal' in part && typeof part.literal === 'string') {
+      template.push({ literal: part.literal });
+    } else if ('variable' in part && typeof part.variable === 'string') {
+      template.push({ variable: part.variable });
+    } else {
+      throw Error(`${errorPrefix} contains a part without literal or variable`);
+    }
+  }
+  return template;
+}


### PR DESCRIPTION
The text and URL of the link come from a provided template file.

For now, the only variable that can be passed to the template is docker-image-sha256-63.

(We have designed this specifically so that database migration promotions can link to GCP logs for a k8s job that ran `flyway info`.)