### PR TITLE
New optional input: frozen-environments-file

### DIFF
--- a/__tests__/__snapshots__/update-docker-tags.test.ts.snap
+++ b/__tests__/__snapshots__/update-docker-tags.test.ts.snap
@@ -39,3 +39,43 @@ some-service-top-level:
     tag: from-mutable---000123-abcd
 "
 `;
+
+exports[`action updates docker tags 2`] = `
+"some-service-dev0:
+  dockerImage:
+    repository: foo
+    trackMutableTag: from-mutable
+    tag: from-mutable---000123-abcd
+
+some-service-dev1:
+  dockerImage:
+    repository: foo
+    trackMutableTag: from-something-random
+    tag: from-something-random---000123-abcd
+
+some-service-dev2:
+  dockerImage:
+    repository: foo
+    trackMutableTag: needs-update
+    tag: needs-update---000123-abcd
+
+
+some-service-dev3:
+  dockerImage:
+    repository: foo
+    trackMutableTag: can-stay-same
+    tag: can-stay-same---0123-abcd
+
+some-service-dev4:
+  dockerImage:
+    repository: foo
+    trackMutableTag: should-roll-back-not-forward
+    tag: should-roll-back-not-forward---000100-abcd
+
+some-service-top-level:
+  track: from-mutable
+  dockerImage:
+    repository: foo
+    tag: from-mutable---000123-abcd
+"
+`;

--- a/__tests__/__snapshots__/update-git-refs.test.ts.snap
+++ b/__tests__/__snapshots__/update-git-refs.test.ts.snap
@@ -147,3 +147,48 @@ some-service-top-level:
     ref: "immutable-pr-1234-hooray"   # this should change but stay double-quoted!
 "
 `;
+
+exports[`action updates git refs 2`] = `
+"some-service-dev0:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: "immutable-pr-1234-hooray"   # this should change but stay double-quoted!
+    trackMutableRef: pr-1234
+
+some-service-dev1:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref:      'abcdef'   # this should change but stay single-quoted!
+    trackMutableRef: pr-1234
+
+some-service-staging:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    trackMutableRef: main
+
+    ref:        immutable-main-hooray  #this can stay unquoted because it won't look like a number
+
+some-service-prod:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: abcdef1234    # NO TOUCHING! No tracking.
+
+another:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: '12345678'   # this becomes a number and will definitely need to be quoted
+    trackMutableRef: make-it-numeric
+
+some-service-top-level:
+  track: pr-1234
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref: "immutable-pr-1234-hooray"   # this should change but stay double-quoted!
+"
+`;

--- a/__tests__/__snapshots__/update-promoted-values.test.ts.snap
+++ b/__tests__/__snapshots__/update-promoted-values.test.ts.snap
@@ -77,3 +77,29 @@ some-service-not-selected:
     ref:    overwrite-me      # this will not be updated because of the regexp
 "
 `;
+
+exports[`action updates git refs 2`] = `
+"some-service-staging:
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    trackMutableRef: main
+    ref:        "abcdef1234567"
+
+some-service-prod:
+  promote:
+    from: some-service-staging
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref:    overwrite-me      # please
+
+some-service-not-selected:
+  promote:
+    from: some-service-staging
+  gitConfig:
+    repoURL: https://github.com/apollographql/some-repo.git
+    path: services/hello-world
+    ref:    abcdef1234567      # this will not be updated because of the regexp
+"
+`;

--- a/__tests__/update-docker-tags.test.ts
+++ b/__tests__/update-docker-tags.test.ts
@@ -50,13 +50,28 @@ describe('action', () => {
     const newContents = await updateDockerTags(
       contents,
       dockerRegistryClient,
+      new Set<string>(),
       logger,
     );
     expect(newContents).toMatchSnapshot();
 
     // It should be idempotent in this case.
-    expect(await updateDockerTags(contents, dockerRegistryClient, logger)).toBe(
-      newContents,
+    expect(
+      await updateDockerTags(
+        newContents,
+        dockerRegistryClient,
+        new Set<string>(),
+        logger,
+      ),
+    ).toBe(newContents);
+
+    // Update the original one but with one service frozen.
+    const frozenContents = await updateDockerTags(
+      contents,
+      dockerRegistryClient,
+      new Set<string>(['some-service-dev2']),
+      logger,
     );
+    expect(frozenContents).toMatchSnapshot();
   });
 });

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -31,19 +31,44 @@ async function fixture(filename: string): Promise<string> {
 describe('action', () => {
   it('updates git refs', async () => {
     const contents = await fixture('sample.yaml');
-    const newContents = await updateGitRefs(contents, mockGitHubClient, logger);
+    const newContents = await updateGitRefs(
+      contents,
+      mockGitHubClient,
+      new Set<string>(),
+      logger,
+    );
     expect(newContents).toMatchSnapshot();
 
     // It should be idempotent in this case.
-    expect(await updateGitRefs(newContents, mockGitHubClient, logger)).toBe(
-      newContents,
-    );
+    expect(
+      await updateGitRefs(
+        newContents,
+        mockGitHubClient,
+        new Set<string>(),
+        logger,
+      ),
+    ).toBe(newContents);
+
+    // Update the first one again but freeze one environment.
+    expect(
+      await updateGitRefs(
+        contents,
+        mockGitHubClient,
+        new Set<string>(['some-service-dev1']),
+        logger,
+      ),
+    ).toMatchSnapshot();
   });
 
   it('updates git ref when repoURL/path are in `global`', async () => {
     const contents = await fixture('global.yaml');
     expect(
-      await updateGitRefs(contents, mockGitHubClient, logger),
+      await updateGitRefs(
+        contents,
+        mockGitHubClient,
+        new Set<string>(),
+        logger,
+      ),
     ).toMatchSnapshot();
   });
 
@@ -65,13 +90,23 @@ describe('action', () => {
 
     // First snapshot: ref should still be 'old' because tree SHA matches.
     expect(
-      await updateGitRefs(contents, mockGithubClientTreeSHA, logger),
+      await updateGitRefs(
+        contents,
+        mockGithubClientTreeSHA,
+        new Set<string>(),
+        logger,
+      ),
     ).toMatchSnapshot();
 
     treeSHAForNew = 'bbbb';
     // Second snapshot: ref should now be 'new' because tree SHA has changed.
     expect(
-      await updateGitRefs(contents, mockGithubClientTreeSHA, logger),
+      await updateGitRefs(
+        contents,
+        mockGithubClientTreeSHA,
+        new Set<string>(),
+        logger,
+      ),
     ).toMatchSnapshot();
   });
 
@@ -94,7 +129,12 @@ describe('action', () => {
     const contents = await fixture('tree-sha.yaml');
 
     expect(
-      await updateGitRefs(contents, mockGithubClientTreeSHA, logger),
+      await updateGitRefs(
+        contents,
+        mockGithubClientTreeSHA,
+        new Set<string>(),
+        logger,
+      ),
     ).toMatchSnapshot();
   });
 
@@ -114,7 +154,12 @@ describe('action', () => {
     const contents = await fixture('docker-tree-sha.yaml');
 
     expect(
-      await updateGitRefs(contents, mockGithubClientTreeSHA, logger),
+      await updateGitRefs(
+        contents,
+        mockGithubClientTreeSHA,
+        new Set<string>(),
+        logger,
+      ),
     ).toMatchSnapshot();
   });
 
@@ -137,7 +182,12 @@ describe('action', () => {
     const contents = await fixture('docker-tree-sha.yaml');
 
     expect(
-      await updateGitRefs(contents, mockGithubClientTreeSHA, logger),
+      await updateGitRefs(
+        contents,
+        mockGithubClientTreeSHA,
+        new Set<string>(),
+        logger,
+      ),
     ).toMatchSnapshot();
   });
 });

--- a/__tests__/update-promoted-values.test.ts
+++ b/__tests__/update-promoted-values.test.ts
@@ -18,6 +18,7 @@ describe('action', () => {
     const { newContents } = await updatePromotedValues(
       contents,
       'prod',
+      new Set<string>(),
       logger,
     );
     expect(newContents).toMatchSnapshot();
@@ -26,15 +27,26 @@ describe('action', () => {
     const { newContents: actual } = await updatePromotedValues(
       newContents,
       'prod',
+      new Set<string>(),
       logger,
     );
     expect(actual).toBe(newContents);
+
+    // Update the first one again but freeze one environment.
+    const { newContents: frozenContents } = await updatePromotedValues(
+      contents,
+      null,
+      new Set<string>(['some-service-prod']),
+      logger,
+    );
+    expect(frozenContents).toMatchSnapshot();
   });
 
   it('respects defaults and explicit specifications for yamlPaths', async () => {
     const { newContents } = await updatePromotedValues(
       await fixture('yaml-paths-defaults.yaml'),
       null,
+      new Set<string>(),
       logger,
     );
 
@@ -43,8 +55,8 @@ describe('action', () => {
 
   it('throws if no default yamlPaths entry works', async () => {
     const contents = await fixture('default-fails.yaml');
-    await expect(updatePromotedValues(contents, null, logger)).rejects.toThrow(
-      'none of the default promoted paths',
-    );
+    await expect(
+      updatePromotedValues(contents, null, new Set<string>(), logger),
+    ).rejects.toThrow('none of the default promoted paths');
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,9 @@ inputs:
   
   link-template-file:
     description: 'If provided, a path to a YAML file mapping from template names to link templates. A template is a `text` and an `url`, each of which is a list of objects, each of which is of the form `{literal: "literal text"}` or `{variable: "variable-name"}.'
+  
+  frozen-environments-file:
+    description: 'If provided, a path to a YAML file listing environment names where track and promote blocks are ignored'
 
 outputs:
   suggested-promotion-branch-name:

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -30,6 +30,7 @@ const DEFAULT_YAML_PATHS = [
 export async function updatePromotedValues(
   contents: string,
   promotionTargetRegexp: string | null,
+  frozenEnvironments: Set<string>,
   _logger: PrefixingLogger,
   dockerRegistryClient: DockerRegistryClient | null = null,
   gitHubClient: GitHubClient | null = null,
@@ -63,6 +64,7 @@ export async function updatePromotedValues(
     dockerRegistryClient,
     gitHubClient,
     linkTemplateMap,
+    frozenEnvironments,
   );
 
   logger.info('Copying values');
@@ -79,6 +81,7 @@ async function findPromotes(
   dockerRegistryClient: DockerRegistryClient | null,
   gitHubClient: GitHubClient | null,
   linkTemplateMap: LinkTemplateMap | null,
+  frozenEnvironments: Set<string>,
 ): Promise<{
   promotes: Promote[];
   promotionsByTargetEnvironment: PromotionsByTargetEnvironment | null;
@@ -118,6 +121,9 @@ async function findPromotes(
   }
 
   for (const [myName, me] of blocks) {
+    if (frozenEnvironments.has(myName)) {
+      continue;
+    }
     if (promotionTargetRE2 && !promotionTargetRE2.test(myName)) {
       continue;
     }


### PR DESCRIPTION
If given, this file should contain a list like

```
- staging
- prod
```

and all track and promote commands will ignore blocks whose names exactly match one of these entries. (You can still promote *from* one of these environments, just not to it.)