### PR TITLE
refactor: remove checks that throw error if the container repository contains a slash

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -46,7 +46,7 @@ jobs:
         id: diff
         run: |
           if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build. See status below:"
+            echo "Detected uncommitted changes after build. Did you forget to run 'npm run all'? See status below:"
             git diff --ignore-space-at-eol --text dist/
             exit 1
           fi

--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -86,12 +86,6 @@ export class ArtifactRegistryDockerRegistryClient {
     core.info(
       `running diff docker tags ${prevTag} ${nextTag} ${dockerImageRepository}`,
     );
-    // Input is relatively trusted; this is largely to prevent mistaken uses
-    // like specifying a full Docker-style repository with slashes.
-    if (dockerImageRepository.includes('/')) {
-      throw Error('repository cannot contain a slash');
-    }
-
     // Note: we don't need `listTagsAsync` (which is recommended) because we
     // only care about the first element in the result array, which is the list of tags.
     // https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#auto-pagination
@@ -126,11 +120,6 @@ export class ArtifactRegistryDockerRegistryClient {
     dockerImageRepository,
     tag,
   }: GetAllEquivalentTagsOptions): Promise<string[]> {
-    // Input is relatively trusted; this is largely to prevent mistaken uses
-    // like specifying a full Docker-style repository with slashes.
-    if (dockerImageRepository.includes('/')) {
-      throw Error('repository cannot contain a slash');
-    }
     if (tag.includes('/')) {
       throw Error('tag cannot contain a slash');
     }


### PR DESCRIPTION
* this is to support multi-level repository names composed of a namespace and image name