### PR TITLE
fix: use encodeURIComponent for the repository input

### DIFF
--- a/src/artifactRegistry.ts
+++ b/src/artifactRegistry.ts
@@ -98,7 +98,7 @@ export class ArtifactRegistryDockerRegistryClient {
       await this.client.listTags({
         parent: this.client.pathTemplates.packagePathTemplate.render({
           ...this.repositoryFields,
-          package: dockerImageRepository,
+          package: encodeURIComponent(dockerImageRepository),
         }),
       })
     )[0].map((iTag) => {
@@ -126,7 +126,7 @@ export class ArtifactRegistryDockerRegistryClient {
 
     const tagPath = this.client.pathTemplates.tagPathTemplate.render({
       ...this.repositoryFields,
-      package: dockerImageRepository,
+      package: encodeURIComponent(dockerImageRepository),
       tag,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,10 +125,9 @@ export async function main(): Promise<void> {
 
     let dockerRegistryClient: DockerRegistryClient | null = null;
     let finalizeDockerRegistryClient: (() => Promise<void>) | null = null;
-    const artifactRegistryRepository = encodeURIComponent(
+    const artifactRegistryRepository =
       core.getInput('artifact-registry-repository') ||
-        core.getInput('update-docker-tags-for-artifact-registry-repository'),
-    );
+      core.getInput('update-docker-tags-for-artifact-registry-repository');
     if (artifactRegistryRepository) {
       const artifactRegistryDockerRegistryClient =
         new ArtifactRegistryDockerRegistryClient(artifactRegistryRepository);

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,9 +125,10 @@ export async function main(): Promise<void> {
 
     let dockerRegistryClient: DockerRegistryClient | null = null;
     let finalizeDockerRegistryClient: (() => Promise<void>) | null = null;
-    const artifactRegistryRepository =
+    const artifactRegistryRepository = encodeURIComponent(
       core.getInput('artifact-registry-repository') ||
-      core.getInput('update-docker-tags-for-artifact-registry-repository');
+        core.getInput('update-docker-tags-for-artifact-registry-repository'),
+    );
     if (artifactRegistryRepository) {
       const artifactRegistryDockerRegistryClient =
         new ArtifactRegistryDockerRegistryClient(artifactRegistryRepository);


### PR DESCRIPTION
* the artifact registry's client will throw an error if a slash is in the repository's string value, uri-encoding will fix this.