### PR TITLE
Allow urls to be optional in links

### DIFF
--- a/__tests__/__fixtures__/templates/templates.yaml
+++ b/__tests__/__fixtures__/templates/templates.yaml
@@ -6,3 +6,7 @@ link-one:
     - literal: 'https://some-site.example/logs/query?foo='
     - variable: 'foo'
     - literal: '&bar=yay'
+
+link-two:
+  text:
+    - literal: "Don't forget to do the thing"

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -1,15 +1,24 @@
 import { join } from 'path';
-import { readLinkTemplateMapFile, renderLinkTemplate } from '../src/templates';
+import {
+  LinkTemplateMap,
+  readLinkTemplateMapFile,
+  renderLinkTemplate,
+} from '../src/templates';
 
 function fixtureFilename(filename: string): string {
   return join(__dirname, '__fixtures__', 'templates', filename);
 }
 
 describe('templates', () => {
-  it('renders a template', async () => {
-    const templateMap = await readLinkTemplateMapFile(
+  let templateMap: LinkTemplateMap;
+
+  beforeEach(async () => {
+    templateMap = await readLinkTemplateMapFile(
       fixtureFilename('templates.yaml'),
     );
+  });
+
+  it('renders a template', () => {
     expect(
       renderLinkTemplate(
         templateMap,
@@ -22,6 +31,14 @@ describe('templates', () => {
     ).toStrictEqual({
       text: 'Link to hooray',
       url: 'https://some-site.example/logs/query?foo=hooray&bar=yay',
+    });
+  });
+
+  it('renders without a url', () => {
+    expect(
+      renderLinkTemplate(templateMap, 'link-two', new Map()),
+    ).toStrictEqual({
+      text: "Don't forget to do the thing",
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,7 +427,11 @@ function formatPromotedCommits(
             environmentPromotions;
           const lines = [`  - ${environment}\n`];
           for (const link of links) {
-            lines.push(`    + [${link.text}](${link.url})\n`);
+            if (link.url) {
+              lines.push(`    + [${link.text}](${link.url})\n`);
+            } else {
+              lines.push(`    + ${link.text}\n`);
+            }
           }
           let alreadyMentionedGitNoCommits = false;
           if (dockerImage && dockerImage.promotionInfo.type !== 'no-change') {


### PR DESCRIPTION
It would be nice if we could add warnings to particular services that need a callout, where the full info can fit in the message itself.  For example, on some services I'd like a message that says "Don't forget to do the thing".  I went down a few different ways of adding this feature, but this changeset was by far the simplest, both conceptually and in code.  If someone is omitting a url, they did it on purpose or it's an easy fix.
