### PR TITLE
[FOUN-552] Reorganize PR message to group apps with identical promotions together

### DIFF
--- a/src/format-promoted-commits.ts
+++ b/src/format-promoted-commits.ts
@@ -1,0 +1,77 @@
+import { PromotionsByTargetEnvironment } from './promotionInfo';
+
+export function formatPromotedCommits(
+  promotionsByFileThenEnvironment: Map<string, PromotionsByTargetEnvironment>,
+): string {
+  return [...promotionsByFileThenEnvironment.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([filename, promotionsByTargetEnvironment]) => {
+      const fileHeader = `* ${filename}\n`;
+      const byEnvironment = [...promotionsByTargetEnvironment.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([environment, environmentPromotions]) => {
+          const { trimmedRepoURL, gitConfigPromotionInfo, dockerImage, links } =
+            environmentPromotions;
+          const lines = [`  - ${environment}\n`];
+          for (const link of links) {
+            if (link.url) {
+              lines.push(`    + [${link.text}](${link.url})\n`);
+            } else {
+              lines.push(`    + ${link.text}\n`);
+            }
+          }
+          let alreadyMentionedGitNoCommits = false;
+          if (dockerImage && dockerImage.promotionInfo.type !== 'no-change') {
+            let maybeGitConfigNoCommits = '';
+            if (gitConfigPromotionInfo.type === 'no-commits') {
+              alreadyMentionedGitNoCommits = true;
+              maybeGitConfigNoCommits =
+                ' (and the git ref for the Helm chart made a no-op change to match)';
+            }
+            lines.push(
+              `    + Changes to Docker image \`${dockerImage.repository}\`${maybeGitConfigNoCommits}\n`,
+              ...(dockerImage.promotionInfo.type === 'no-commits'
+                ? ['No changes affect the built Docker image.']
+                : dockerImage.promotionInfo.type === 'unknown'
+                  ? [
+                      `Cannot determine set of changes to the Docker image: ${dockerImage.promotionInfo.message}`,
+                    ]
+                  : dockerImage.promotionInfo.commitSHAs.map(
+                      (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
+                    )
+              ).map((line) => `      * ${line}\n`),
+            );
+          }
+          if (
+            gitConfigPromotionInfo.type !== 'no-change' &&
+            !alreadyMentionedGitNoCommits
+          ) {
+            lines.push(
+              `    + Changes to Helm chart\n`,
+              ...(gitConfigPromotionInfo.type === 'no-commits'
+                ? // This one shows up when the ref changes even though there are no
+
+                  // new commits. This is something we do to try to make the ref
+                  // match the Docker tag, so it actually does happen frequently
+                  // (though usually only when the Docker tag is making a
+                  // substantive change) so this message might end up being a bit
+                  // spammy; we can remove it if it's not helpful.
+                  [
+                    'The git ref for the Helm chart has changed, but there are no new commits in the range.',
+                  ]
+                : gitConfigPromotionInfo.type === 'unknown'
+                  ? [
+                      `Cannot determine set of changes to the Helm chart: ${gitConfigPromotionInfo.message}`,
+                    ]
+                  : gitConfigPromotionInfo.commitSHAs.map(
+                      (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
+                    )
+              ).map((line) => `      * ${line}\n`),
+            );
+          }
+          return lines.join('');
+        });
+      return fileHeader + byEnvironment.join('\n');
+    })
+    .join('');
+}

--- a/src/format-promoted-commits.ts
+++ b/src/format-promoted-commits.ts
@@ -116,7 +116,7 @@ export function formatPromotedCommits(
             if (gitConfigPromotionInfo.type === 'no-commits') {
               alreadyMentionedGitNoCommits = true;
               maybeGitConfigNoCommits =
-                ' (and the git ref for the Helm chart made a no-op change to match)';
+                ' (matching Helm chart update is a no-op)';
             }
             text.push(
               `Changes to Docker images${maybeGitConfigNoCommits}:\n`,
@@ -138,7 +138,7 @@ export function formatPromotedCommits(
             !alreadyMentionedGitNoCommits
           ) {
             text.push(
-              `Changes to Helm chart\n`,
+              `Changes to Helm chart:\n`,
               ...(gitConfigPromotionInfo.type === 'no-commits'
                 ? // This one shows up when the ref changes even though there are no
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { PrefixingLogger } from './log';
 import { inspect } from 'util';
 import { PromotionsByTargetEnvironment } from './promotionInfo';
 import { LinkTemplateMap, readLinkTemplateMapFile } from './templates';
+import { formatPromotedCommits } from './format-promoted-commits';
 
 export class AnnotatedError extends Error {
   startLine: number | undefined;
@@ -38,10 +39,7 @@ export class AnnotatedError extends Error {
     {
       range,
       lineCounter,
-    }: {
-      range: yaml.Range | null | undefined;
-      lineCounter: yaml.LineCounter;
-    },
+    }: { range: yaml.Range | null | undefined; lineCounter: yaml.LineCounter },
   ) {
     super(message);
     if (range) {
@@ -231,17 +229,12 @@ export async function main(): Promise<void> {
         if (error instanceof AnnotatedError) {
           errors.push({
             error: error.message,
-            annotation: {
-              ...error,
-              file: filename,
-            },
+            annotation: { ...error, file: filename },
           });
         } else {
           errors.push({
             error: inspect(error),
-            annotation: {
-              file: filename,
-            },
+            annotation: { file: filename },
           });
         }
       }
@@ -411,82 +404,6 @@ async function maybeReadAPICache(
     gitHub: parsed.gitHub,
     dockerRegistry: parsed.dockerRegistry,
   };
-}
-
-function formatPromotedCommits(
-  promotionsByFileThenEnvironment: Map<string, PromotionsByTargetEnvironment>,
-): string {
-  return [...promotionsByFileThenEnvironment.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([filename, promotionsByTargetEnvironment]) => {
-      const fileHeader = `* ${filename}\n`;
-      const byEnvironment = [...promotionsByTargetEnvironment.entries()]
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([environment, environmentPromotions]) => {
-          const { trimmedRepoURL, gitConfigPromotionInfo, dockerImage, links } =
-            environmentPromotions;
-          const lines = [`  - ${environment}\n`];
-          for (const link of links) {
-            if (link.url) {
-              lines.push(`    + [${link.text}](${link.url})\n`);
-            } else {
-              lines.push(`    + ${link.text}\n`);
-            }
-          }
-          let alreadyMentionedGitNoCommits = false;
-          if (dockerImage && dockerImage.promotionInfo.type !== 'no-change') {
-            let maybeGitConfigNoCommits = '';
-            if (gitConfigPromotionInfo.type === 'no-commits') {
-              alreadyMentionedGitNoCommits = true;
-              maybeGitConfigNoCommits =
-                ' (and the git ref for the Helm chart made a no-op change to match)';
-            }
-            lines.push(
-              `    + Changes to Docker image \`${dockerImage.repository}\`${maybeGitConfigNoCommits}\n`,
-              ...(dockerImage.promotionInfo.type === 'no-commits'
-                ? ['No changes affect the built Docker image.']
-                : dockerImage.promotionInfo.type === 'unknown'
-                  ? [
-                      `Cannot determine set of changes to the Docker image: ${dockerImage.promotionInfo.message}`,
-                    ]
-                  : dockerImage.promotionInfo.commitSHAs.map(
-                      (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
-                    )
-              ).map((line) => `      * ${line}\n`),
-            );
-          }
-          if (
-            gitConfigPromotionInfo.type !== 'no-change' &&
-            !alreadyMentionedGitNoCommits
-          ) {
-            lines.push(
-              `    + Changes to Helm chart\n`,
-              ...(gitConfigPromotionInfo.type === 'no-commits'
-                ? // This one shows up when the ref changes even though there are no
-                  // new commits. This is something we do to try to make the ref
-                  // match the Docker tag, so it actually does happen frequently
-                  // (though usually only when the Docker tag is making a
-                  // substantive change) so this message might end up being a bit
-                  // spammy; we can remove it if it's not helpful.
-
-                  [
-                    'The git ref for the Helm chart has changed, but there are no new commits in the range.',
-                  ]
-                : gitConfigPromotionInfo.type === 'unknown'
-                  ? [
-                      `Cannot determine set of changes to the Helm chart: ${gitConfigPromotionInfo.message}`,
-                    ]
-                  : gitConfigPromotionInfo.commitSHAs.map(
-                      (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
-                    )
-              ).map((line) => `      * ${line}\n`),
-            );
-          }
-          return lines.join('');
-        });
-      return fileHeader + byEnvironment.join('\n');
-    })
-    .join('');
 }
 
 export async function readFrozenEnvironmentsFile(

--- a/src/promotionInfo.ts
+++ b/src/promotionInfo.ts
@@ -39,15 +39,26 @@ export type PromotionInfo =
   | PromotionInfoNoChange
   | PromotionInfoUnknown;
 
-export interface EnvironmentPromotions {
+// This is the set of data about a promotion that, if two apps have the same
+// values for it, will make them be treated as having identical promotions (ie,
+// we'll only have one section about it in the PR description). Notably, it does
+// not include the Docker image (or app name) because we often (due to
+// monorepos) have the same set of commits contributing to multiple Docker
+// images.
+export interface PromotionSet {
   trimmedRepoURL: string;
   gitConfigPromotionInfo: PromotionInfo;
-  dockerImage: {
-    repository: string;
-    promotionInfo: PromotionInfo;
-  } | null; // null if there's no Docker image being tracked
+  // null if there's no Docker image being tracked
+  dockerImagePromotionInfo: PromotionInfo | null;
   links: Link[];
+}
+export interface PromotionSetWithDockerImage {
+  promotionSet: PromotionSet;
+  dockerImageRepository: string | null; // null if there's no Docker image being tracked
 }
 
 // Map from environment (eg `staging`) to EnvironmentPromotions.
-export type PromotionsByTargetEnvironment = Map<string, EnvironmentPromotions>;
+export type PromotionsByTargetEnvironment = Map<
+  string,
+  PromotionSetWithDockerImage
+>;


### PR DESCRIPTION
Previously, commit messages were structured as "filename -> target environment -> list of commits to promote". Often in an monorepo environment where many Docker images are built from the same changes, many apps ended up with the same list of commits to promote.

Now they are structured as "target environment -> group by list of commits to promote -> filename".

Some other slight formatting changes include only naming the Docker image repository if it differs from the app name, and leaving off the actual YAML file name from the app (just keeping in its path).