### PR TITLE
Add functionality to retrack applications to main for closed PRs

### DIFF
--- a/__tests__/__snapshots__/cleanup-closed-pr-tracking.test.ts.snap
+++ b/__tests__/__snapshots__/cleanup-closed-pr-tracking.test.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cleanupClosedPrTracking should handle PR lookup errors by leaving PR references unchanged 1`] = `
+"
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
+dev:
+  track: pr-999
+  gitConfig:
+    ref: c0ffee
+"
+`;
+
+exports[`cleanupClosedPrTracking should not change pr references that are open 1`] = `
+"
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
+dev:
+  track: pr-100
+  gitConfig:
+    ref: c0ffee
+staging:
+  track: main
+  gitConfig:
+    ref: c0ffee
+prod:
+  promote:
+    from: staging
+"
+`;
+
+exports[`cleanupClosedPrTracking should not modify YAML unnecessarily 1`] = `
+"# Top level comment
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
+# Development environment
+dev:
+  track: main  # Inline comment
+  gitConfig:
+    ref: c0ffee
+staging:
+  track: main  # Also tracking main
+  gitConfig:
+    ref: deadbeef
+prod:
+  promote:
+    from: staging  # Promote from staging
+"
+`;
+
+exports[`cleanupClosedPrTracking should replace closed PR references with main 1`] = `
+"
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
+dev:
+  track: main
+  gitConfig:
+    ref: c0ffee
+staging:
+  track: main
+  gitConfig:
+    ref: c0ffee
+prod:
+  promote:
+    from: staging
+"
+`;

--- a/__tests__/caching.test.ts
+++ b/__tests__/caching.test.ts
@@ -47,6 +47,9 @@ describe('CachingGitHubClient caches', () => {
       async getCommitSHAsForPath() {
         return [];
       },
+      async getPullRequest() {
+        return { state: 'open' };
+      },
     });
 
     async function exp(
@@ -80,6 +83,9 @@ describe('CachingGitHubClient caches', () => {
       },
       async getCommitSHAsForPath() {
         return [];
+      },
+      async getPullRequest() {
+        return { state: 'open' };
       },
     });
 

--- a/__tests__/caching.test.ts
+++ b/__tests__/caching.test.ts
@@ -48,7 +48,7 @@ describe('CachingGitHubClient caches', () => {
         return [];
       },
       async getPullRequest() {
-        return { state: 'open' };
+        return { state: 'open', title: 'Test PR' };
       },
     });
 
@@ -85,7 +85,7 @@ describe('CachingGitHubClient caches', () => {
         return [];
       },
       async getPullRequest() {
-        return { state: 'open' };
+        return { state: 'open', title: 'Test PR' };
       },
     });
 

--- a/__tests__/cleanup-closed-pr-tracking.test.ts
+++ b/__tests__/cleanup-closed-pr-tracking.test.ts
@@ -1,7 +1,4 @@
-import {
-  cleanupClosedPrTracking,
-  readFrozenEnvironmentsFile,
-} from '../src/index';
+import { cleanupClosedPrTracking } from '../src/index';
 import { GitHubClient } from '../src/github';
 import { PrefixingLogger } from '../src/log';
 

--- a/__tests__/cleanup-closed-pr-tracking.test.ts
+++ b/__tests__/cleanup-closed-pr-tracking.test.ts
@@ -1,4 +1,7 @@
-import { cleanupClosedPrTracking } from '../src/index';
+import {
+  cleanupClosedPrTracking,
+  readFrozenEnvironmentsFile,
+} from '../src/index';
 import { GitHubClient } from '../src/github';
 import { PrefixingLogger } from '../src/log';
 
@@ -29,76 +32,132 @@ function createMockGitHubClient(
 
 describe('cleanupClosedPrTracking', () => {
   it('should replace closed PR references with main', async () => {
-    const yamlContent = `
+    const contents = `
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
 dev:
   track: pr-123
+  gitConfig:
+    ref: c0ffee
 staging:
   track: main
+  gitConfig:
+    ref: c0ffee
 prod:
   promote:
     from: staging
 `;
 
-    const mockGitHubClient = createMockGitHubClient({
+    const gitHubClient = createMockGitHubClient({
       123: 'closed',
     });
 
-    const result = await cleanupClosedPrTracking(
-      yamlContent,
-      'owner/repo',
-      mockGitHubClient,
+    const result = await cleanupClosedPrTracking({
+      contents,
+      gitHubClient,
       logger,
-    );
+      frozenEnvironments: new Set(),
+    });
 
-    expect(result.changesCount).toBe(1);
-    expect((result.newContents.match(/track: main/g) || []).length).toBe(2);
+    expect((result.contents.match(/track: main/g) || []).length).toBe(2);
   });
 
   it('should not change pr references that are open', async () => {
-    const yamlContent = `
+    const contents = `
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
 dev:
   track: pr-100
+  gitConfig:
+    ref: c0ffee
 staging:
   track: pr-123
+  gitConfig:
+    ref: c0ffee
 prod:
   promote:
     from: staging
 `;
 
-    const mockGitHubClient = createMockGitHubClient({
+    const gitHubClient = createMockGitHubClient({
       123: 'closed',
       100: 'open',
     });
 
-    const result = await cleanupClosedPrTracking(
-      yamlContent,
-      'owner/repo',
-      mockGitHubClient,
+    const result = await cleanupClosedPrTracking({
+      contents,
+      gitHubClient,
       logger,
-    );
+      frozenEnvironments: new Set(),
+    });
 
-    expect(result.changesCount).toBe(1);
-    expect(result.newContents).toContain('track: pr-100');
-    expect(result.newContents).toContain('track: main');
+    expect(result.contents).toContain('track: pr-100');
+    expect(result.contents).toContain('track: main');
   });
 
   it('should handle PR lookup errors by leaving PR references unchanged', async () => {
-    const yamlContent = `
-track: pr-999
+    const contents = `
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
+dev:
+  track: pr-999
+  gitConfig:
+    ref: c0ffee
 `;
 
-    const mockGitHubClient = createMockGitHubClient({
+    const gitHubClient = createMockGitHubClient({
       999: 'error',
     });
 
-    const result = await cleanupClosedPrTracking(
-      yamlContent,
-      'owner/repo',
-      mockGitHubClient,
+    const result = await cleanupClosedPrTracking({
+      contents,
+      gitHubClient,
       logger,
-    );
+      frozenEnvironments: new Set(),
+    });
 
-    expect(result.changesCount).toBe(0);
-    expect(result.newContents).toContain('track: pr-999');
+    expect(result.contents).toContain('track: pr-999');
+  });
+
+  it('should not modify YAML unnecessarily', async () => {
+    const contents = `# Top level comment
+global:
+  gitConfig:
+    repoURL: https://github.com/owner/repo
+    path: some/path
+# Development environment
+dev:
+  track: pr-123  # Inline comment
+  gitConfig:
+    ref: c0ffee
+staging:
+  track: main  # Also tracking main
+  gitConfig:
+    ref: deadbeef
+prod:
+  promote:
+    from: staging  # Promote from staging
+`;
+
+    const gitHubClient = createMockGitHubClient({
+      123: 'closed',
+    });
+
+    const result = await cleanupClosedPrTracking({
+      contents,
+      gitHubClient,
+      logger,
+      frozenEnvironments: new Set(),
+    });
+
+    expect(result.contents).toContain('# Top level comment');
+    expect(result.contents).toContain('# Inline comment');
+    expect((result.contents.match(/track: main/g) || []).length).toBe(2);
   });
 });

--- a/__tests__/cleanup-closed-pr-tracking.test.ts
+++ b/__tests__/cleanup-closed-pr-tracking.test.ts
@@ -58,7 +58,9 @@ prod:
       frozenEnvironments: new Set(),
     });
 
+    expect(result.contents).not.toContain('track: pr-123');
     expect((result.contents.match(/track: main/g) || []).length).toBe(2);
+    expect(result.contents).toMatchSnapshot();
   });
 
   it('should not change pr references that are open', async () => {
@@ -93,7 +95,9 @@ prod:
     });
 
     expect(result.contents).toContain('track: pr-100');
+    expect(result.contents).not.toContain('track: pr-123');
     expect(result.contents).toContain('track: main');
+    expect(result.contents).toMatchSnapshot();
   });
 
   it('should handle PR lookup errors by leaving PR references unchanged', async () => {
@@ -120,6 +124,7 @@ dev:
     });
 
     expect(result.contents).toContain('track: pr-999');
+    expect(result.contents).toMatchSnapshot();
   });
 
   it('should not modify YAML unnecessarily', async () => {
@@ -156,5 +161,6 @@ prod:
     expect(result.contents).toContain('# Top level comment');
     expect(result.contents).toContain('# Inline comment');
     expect((result.contents.match(/track: main/g) || []).length).toBe(2);
+    expect(result.contents).toMatchSnapshot();
   });
 });

--- a/__tests__/cleanup-closed-pr-tracking.test.ts
+++ b/__tests__/cleanup-closed-pr-tracking.test.ts
@@ -1,0 +1,104 @@
+import { cleanupClosedPrTracking } from '../src/index';
+import { GitHubClient } from '../src/github';
+import { PrefixingLogger } from '../src/log';
+
+const logger = PrefixingLogger.silent();
+
+function createMockGitHubClient(
+  prStates: Record<number, 'open' | 'closed' | 'error'>,
+): GitHubClient {
+  return {
+    async resolveRefToSHA() {
+      return 'mock-sha';
+    },
+    async getTreeSHAForPath() {
+      return 'mock-tree-sha';
+    },
+    async getCommitSHAsForPath() {
+      return [];
+    },
+    async getPullRequest({ prNumber }) {
+      const state = prStates[prNumber];
+      if (state === 'error') {
+        throw new Error('Not found');
+      }
+      return { state: state || 'open' };
+    },
+  };
+}
+
+describe('cleanupClosedPrTracking', () => {
+  it('should replace closed PR references with main', async () => {
+    const yamlContent = `
+dev:
+  track: pr-123
+staging:
+  track: main
+prod:
+  promote:
+    from: staging
+`;
+
+    const mockGitHubClient = createMockGitHubClient({
+      123: 'closed',
+    });
+
+    const result = await cleanupClosedPrTracking(
+      yamlContent,
+      'owner/repo',
+      mockGitHubClient,
+      logger,
+    );
+
+    expect(result.changesCount).toBe(1);
+    expect((result.newContents.match(/track: main/g) || []).length).toBe(2);
+  });
+
+  it('should not change pr references that are open', async () => {
+    const yamlContent = `
+dev:
+  track: pr-100
+staging:
+  track: pr-123
+prod:
+  promote:
+    from: staging
+`;
+
+    const mockGitHubClient = createMockGitHubClient({
+      123: 'closed',
+      100: 'open',
+    });
+
+    const result = await cleanupClosedPrTracking(
+      yamlContent,
+      'owner/repo',
+      mockGitHubClient,
+      logger,
+    );
+
+    expect(result.changesCount).toBe(1);
+    expect(result.newContents).toContain('track: pr-100');
+    expect(result.newContents).toContain('track: main');
+  });
+
+  it('should handle PR lookup errors by leaving PR references unchanged', async () => {
+    const yamlContent = `
+track: pr-999
+`;
+
+    const mockGitHubClient = createMockGitHubClient({
+      999: 'error',
+    });
+
+    const result = await cleanupClosedPrTracking(
+      yamlContent,
+      'owner/repo',
+      mockGitHubClient,
+      logger,
+    );
+
+    expect(result.changesCount).toBe(0);
+    expect(result.newContents).toContain('track: pr-999');
+  });
+});

--- a/__tests__/format-cleanup-changes.test.ts
+++ b/__tests__/format-cleanup-changes.test.ts
@@ -1,0 +1,72 @@
+import {
+  formatCleanupChanges,
+  CleanupChange,
+} from '../src/format-cleanup-changes';
+
+describe('formatCleanupChanges', () => {
+  it('should return empty string for no changes', () => {
+    const result = formatCleanupChanges([]);
+    expect(result).toBe('');
+  });
+
+  it('should find single closed PRs', () => {
+    const changes: CleanupChange[] = [
+      {
+        prNumber: 123,
+        prTitle: 'Add new feature',
+        prURL: 'https://github.com/owner/repo/pull/123',
+      },
+    ];
+
+    const result = formatCleanupChanges(changes);
+    expect(result).toContain('Found 1 closed PR:');
+    expect(result).toContain(
+      '- PR [#123](https://github.com/owner/repo/pull/123): Add new feature',
+    );
+  });
+
+  it('should find multiple closed PRs', () => {
+    const changes: CleanupChange[] = [
+      {
+        prNumber: 456,
+        prTitle: 'Second PR',
+        prURL: 'https://github.com/owner/repo/pull/456',
+      },
+      {
+        prNumber: 123,
+        prTitle: 'First PR',
+        prURL: 'https://github.com/owner/repo/pull/123',
+      },
+    ];
+
+    const result = formatCleanupChanges(changes);
+    expect(result).toContain('Found 2 closed PRs:');
+    expect(result).toContain(
+      '- PR [#123](https://github.com/owner/repo/pull/123): First PR',
+    );
+    expect(result).toContain(
+      '- PR [#456](https://github.com/owner/repo/pull/456): Second PR',
+    );
+  });
+
+  it('should sort PRs by number', () => {
+    const changes: CleanupChange[] = [
+      {
+        prNumber: 456,
+        prTitle: 'Second PR',
+        prURL: 'https://github.com/owner/repo/pull/456',
+      },
+      {
+        prNumber: 123,
+        prTitle: 'First PR',
+        prURL: 'https://github.com/owner/repo/pull/123',
+      },
+    ];
+
+    const result = formatCleanupChanges(changes);
+    const lines = result.split('\n');
+    const pr123Index = lines.findIndex((line) => line.includes('#123'));
+    const pr456Index = lines.findIndex((line) => line.includes('#456'));
+    expect(pr123Index).toBeLessThan(pr456Index);
+  });
+});

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -17,6 +17,9 @@ const mockGitHubClient: GitHubClient = {
   async getCommitSHAsForPath() {
     return [];
   },
+  async getPullRequest() {
+    return { state: 'open' };
+  },
 };
 
 const logger = PrefixingLogger.silent();
@@ -84,6 +87,9 @@ describe('action', () => {
       async getCommitSHAsForPath() {
         return [];
       },
+      async getPullRequest() {
+        return { state: 'open' };
+      },
     };
 
     const contents = await fixture('tree-sha.yaml');
@@ -124,6 +130,9 @@ describe('action', () => {
       async getCommitSHAsForPath() {
         return [];
       },
+      async getPullRequest() {
+        return { state: 'open' };
+      },
     };
 
     const contents = await fixture('tree-sha.yaml');
@@ -148,6 +157,9 @@ describe('action', () => {
       },
       async getCommitSHAsForPath() {
         return [];
+      },
+      async getPullRequest() {
+        return { state: 'open' };
       },
     };
 
@@ -176,6 +188,9 @@ describe('action', () => {
       },
       async getCommitSHAsForPath() {
         return [];
+      },
+      async getPullRequest() {
+        return { state: 'open' };
       },
     };
 

--- a/__tests__/update-git-refs.test.ts
+++ b/__tests__/update-git-refs.test.ts
@@ -18,7 +18,7 @@ const mockGitHubClient: GitHubClient = {
     return [];
   },
   async getPullRequest() {
-    return { state: 'open' };
+    return { state: 'open', title: 'Test PR' };
   },
 };
 
@@ -88,7 +88,7 @@ describe('action', () => {
         return [];
       },
       async getPullRequest() {
-        return { state: 'open' };
+        return { state: 'open', title: 'Test PR' };
       },
     };
 
@@ -131,7 +131,7 @@ describe('action', () => {
         return [];
       },
       async getPullRequest() {
-        return { state: 'open' };
+        return { state: 'open', title: 'Test PR' };
       },
     };
 
@@ -159,7 +159,7 @@ describe('action', () => {
         return [];
       },
       async getPullRequest() {
-        return { state: 'open' };
+        return { state: 'open', title: 'Test PR' };
       },
     };
 
@@ -190,7 +190,7 @@ describe('action', () => {
         return [];
       },
       async getPullRequest() {
-        return { state: 'open' };
+        return { state: 'open', title: 'Test PR' };
       },
     };
 

--- a/action.yml
+++ b/action.yml
@@ -38,21 +38,28 @@ inputs:
   parallelism:
     description: 'How many files to process in parallel'
     default: '1'
-  
+
   generate-promoted-commits-markdown:
     description: 'Generates the promoted-commits-markdown output'
     default: 'false'
-  
+
   link-template-file:
     description: 'If provided, a path to a YAML file mapping from template names to link templates. A template is a `text` and an `url`, each of which is a list of objects, each of which is of the form `{literal: "literal text"}` or `{variable: "variable-name"}.'
-  
+
   frozen-environments-file:
     description: 'If provided, a path to a YAML file listing environment names where track and promote blocks are ignored'
+
+  cleanup-closed-pr-tracking:
+    description: 'Clean up track: pr-N patterns where PR N is closed'
+    default: 'false'
+
+  cleanup-target-repository:
+    description: 'Repository to check PR status for cleanup (required when cleanup-closed-pr-tracking is true). Format: owner/repo'
 
 outputs:
   suggested-promotion-branch-name:
     description: 'A combination of the promotion-target-regexp and files inputs with special characters changed to underscores; appropriate for constructing a branch name'
-  
+
   promoted-commits-markdown:
     description: 'Markdown describing the commits being promoted, if update-promoted-values and generate-promoted-commits-markdown are set.'
 

--- a/action.yml
+++ b/action.yml
@@ -53,9 +53,6 @@ inputs:
     description: 'Clean up track: pr-N patterns where PR N is closed'
     default: 'false'
 
-  cleanup-target-repository:
-    description: 'Repository to check PR status for cleanup (required when cleanup-closed-pr-tracking is true). Format: owner/repo'
-
 outputs:
   suggested-promotion-branch-name:
     description: 'A combination of the promotion-target-regexp and files inputs with special characters changed to underscores; appropriate for constructing a branch name'

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,9 @@ outputs:
 
   promoted-commits-markdown:
     description: 'Markdown describing the commits being promoted, if update-promoted-values and generate-promoted-commits-markdown are set.'
+  
+  cleanup-changes-markdown:
+    description: 'Markdown describing closed PR tracking references that were cleaned up, if cleanup-closed-pr-tracking is set.'
 
 runs:
   using: node20

--- a/src/format-cleanup-changes.ts
+++ b/src/format-cleanup-changes.ts
@@ -1,0 +1,27 @@
+export interface CleanupChange {
+  prNumber: number;
+  prTitle: string;
+  prURL: string;
+}
+
+export type CleanupChangesByFile = Map<string, CleanupChange[]>;
+
+export function formatCleanupChanges(changes: CleanupChange[]): string {
+  if (!changes.length) return '';
+
+  const prMap = new Map<number, CleanupChange>();
+  for (const change of changes) {
+    prMap.set(change.prNumber, change);
+  }
+
+  const header = `Found ${changes.length} closed PR${changes.length === 1 ? '' : 's'}:\n\n`;
+
+  const prLines = [...prMap.values()]
+    .sort((a, b) => a.prNumber - b.prNumber)
+    .map(
+      (change) =>
+        `- PR [#${change.prNumber}](${change.prURL}): ${change.prTitle}`,
+    );
+
+  return [header, ...prLines].join('\n');
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -33,6 +33,7 @@ export type PullRequestState = 'open' | 'closed';
 
 export interface PullRequest {
   state: PullRequestState;
+  title: string;
 }
 
 export interface GitHubClient {
@@ -263,7 +264,10 @@ export class OctokitGitHubClient {
       repo,
       pull_number: prNumber,
     });
-    return { state: response.data.state as PullRequestState };
+    return {
+      state: response.data.state as PullRequestState,
+      title: response.data.title,
+    };
   }
 }
 
@@ -315,6 +319,7 @@ export class CachingGitHubClient {
     },
   });
 
+  // We mainly care about the state of the PR, a very dynamic value, so we don't really want to cache it
   private getPullRequestCache = new LRUCache<
     string,
     PullRequest,

--- a/src/github.ts
+++ b/src/github.ts
@@ -319,7 +319,8 @@ export class CachingGitHubClient {
     },
   });
 
-  // We mainly care about the state of the PR, a very dynamic value, so we don't really want to cache it
+  // We mainly care about the state of the PR, a very dynamic value, so this cache is only
+  // for avoiding repeated lookups within a single action run; we don't save it to the Actions cache.
   private getPullRequestCache = new LRUCache<
     string,
     PullRequest,

--- a/src/update-closed-prs.ts
+++ b/src/update-closed-prs.ts
@@ -1,0 +1,67 @@
+import { GitHubClient } from './github';
+import { PrefixingLogger } from './log';
+import { parseYAML } from './yaml';
+import { findTrackables } from './update-git-refs';
+import { CleanupChange } from './format-cleanup-changes';
+
+/**
+ * Updates closed PR tracking references to point to 'main' branch.
+ *
+ * This function scans YAML configuration files for Git references that track
+ * pull requests (in the format "pr-123") and checks if those PRs are closed.
+ * If a PR is closed, the tracking reference is updated to "main".
+ *
+ * @param options - Configuration for the cleanup operation
+ * @param options.contents - The YAML file contents to process
+ * @param options.frozenEnvironments - Set of environment names that should not be modified
+ * @param options.gitHubClient - GitHub client for API calls to check PR status
+ * @param options.logger - Logger for operation feedback
+ * @returns Promise resolving to updated contents and list of changes made
+ */
+export async function cleanupClosedPrTracking(options: {
+  contents: string;
+  frozenEnvironments: Set<string>;
+  gitHubClient: GitHubClient;
+  logger: PrefixingLogger;
+}): Promise<{ contents: string; changes: CleanupChange[] }> {
+  const { contents, frozenEnvironments, gitHubClient, logger } = options;
+
+  const { document, stringify } = parseYAML(contents);
+  if (!document) {
+    return { contents, changes: [] };
+  }
+
+  const changes: CleanupChange[] = [];
+  const trackables = findTrackables(document, frozenEnvironments);
+  for (const trackable of trackables) {
+    const match = trackable.trackMutableRef.match(/^pr-(\d+)$/);
+    if (match && trackable.trackScalarTokenWriter) {
+      const prNumber = parseInt(match[1], 10);
+      try {
+        const pr = await gitHubClient.getPullRequest({
+          repoURL: trackable.repoURL,
+          prNumber,
+        });
+
+        if (pr.state === 'closed') {
+          trackable.trackScalarTokenWriter.write('main');
+          logger.info(`PR #${prNumber} is closed, updated to main`);
+          changes.push({
+            prNumber,
+            prTitle: pr.title,
+            prURL: `${trackable.repoURL}/pull/${prNumber}`,
+          });
+        } else {
+          logger.info(`PR #${prNumber} is ${pr.state}`);
+        }
+      } catch (error) {
+        logger.info(`PR #${prNumber} lookup failed, leaving unchanged`);
+      }
+    }
+  }
+
+  return {
+    contents: stringify(),
+    changes,
+  };
+}

--- a/src/update-docker-tags.ts
+++ b/src/update-docker-tags.ts
@@ -151,9 +151,7 @@ async function checkTagsAgainstArtifactRegistryAndModifyScalars(
           if (e instanceof Error) {
             let message = e.message;
             if (e.message === `5 NOT_FOUND: Requested entity was not found.`) {
-              message = `The tag '${trackable.trackMutableTag}' on the Docker image '${
-                trackable.dockerImageRepository
-              }' does not exist. Check that both the image and tag are spelled correctly.`;
+              message = `The tag '${trackable.trackMutableTag}' on the Docker image '${trackable.dockerImageRepository}' does not exist. Check that both the image and tag are spelled correctly.`;
               if (trackable.trackMutableTag.startsWith('pr-')) {
                 message +=
                   ' Check that the Docker image has been successfully built ' +

--- a/src/update-docker-tags.ts
+++ b/src/update-docker-tags.ts
@@ -151,7 +151,9 @@ async function checkTagsAgainstArtifactRegistryAndModifyScalars(
           if (e instanceof Error) {
             let message = e.message;
             if (e.message === `5 NOT_FOUND: Requested entity was not found.`) {
-              message = `The tag '${trackable.trackMutableTag}' on the Docker image '${trackable.dockerImageRepository}' does not exist. Check that both the image and tag are spelled correctly.`;
+              message = `The tag '${trackable.trackMutableTag}' on the Docker image '${
+                trackable.dockerImageRepository
+              }' does not exist. Check that both the image and tag are spelled correctly.`;
               if (trackable.trackMutableTag.startsWith('pr-')) {
                 message +=
                   ' Check that the Docker image has been successfully built ' +


### PR DESCRIPTION
Devs often forget to do this step which causes constant confusion.  This will enable a workflow that creates a PR that can be merged to do this easily.