### PR TITLE
Feature: Include SHAs which are rolled up in a promotion.

### DIFF
--- a/src/promotion-metadata-types.ts
+++ b/src/promotion-metadata-types.ts
@@ -29,6 +29,8 @@ export const AppPromotion = type({
   target: {
     appName: "string",
   },
+  includedImageSHAs: "string[]",
+  includedConfigSHAs: "string[]"
 });
 
 export type AppPromotion = typeof AppPromotion.infer;

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -390,6 +390,7 @@ async function findPromotes(
               (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
             )
           : []
+        )
       };
 
       // Extract source dockerImage values from fromBlock (optional, but all fields required if present)

--- a/src/update-promoted-values.ts
+++ b/src/update-promoted-values.ts
@@ -377,6 +377,19 @@ async function findPromotes(
         target: {
           appName: `${applicationBaseName}-${myName}`,
         },
+        includedImageSHAs: (
+          dockerImagePromotionInfo.type === "commits"
+          ? dockerImagePromotionInfo.commitSHAs.map(
+            (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
+          )
+          : []
+        ),
+        includedConfigSHAs: (
+          gitConfigPromotionInfo.type === "commits"
+          ? gitConfigPromotionInfo.commitSHAs.map(
+              (commitSHA) => `${trimmedRepoURL}/commit/${commitSHA}`,
+            )
+          : []
       };
 
       // Extract source dockerImage values from fromBlock (optional, but all fields required if present)


### PR DESCRIPTION
# Motivation

As we start to untangle how our code progresses to production, we need to be able to successfully map between a source commit, and all of its downstream impacts.

Presently, we are doing this by breaking each PR's text down into chunks, and looking for app names + commit info.

By including this information in the `prMetadata` itself, we can more simply track this mapping.